### PR TITLE
feat: add corporate environment configuration to setup wizard

### DIFF
--- a/platform-bootstrap/.env.example
+++ b/platform-bootstrap/.env.example
@@ -45,8 +45,9 @@ KERBEROS_CACHE_TICKET=dev/tkt
 
 # Example corporate paths (uncomment and customize):
 # IMAGE_ASTRONOMER=artifactory.company.com/docker-remote/astronomer/ap-airflow:11.10.0
-# IMAGE_PYTHON=artifactory.company.com/docker-remote/library/python:3.11-slim
+# IMAGE_PYTHON=artifactory.company.com/docker-remote/library/python:3.11-alpine
 # IMAGE_ALPINE=artifactory.company.com/docker-remote/library/alpine:3.19
+# IMAGE_MOCKSERVER=artifactory.company.com/docker-remote/mockserver/mockserver:latest
 
 # ==========================================
 # Microsoft ODBC Driver Source (For Kerberos Sidecar)


### PR DESCRIPTION
## Summary

Adds Step 7 to wizard for corporate Artifactory configuration BEFORE building sidecar.

## Problem  

Wizard tried to pull from Docker Hub without asking if corporate blocks it.

## Solution

**New Step 7:**
- Asks: In corporate environment with restricted access?
- If yes: Prompts for Artifactory paths, saves to .env, reminds about docker login
- If no: Uses public internet

Steps renumbered to 11 total.

Wizard now corporate-ready!

🤖 Generated with [Claude Code](https://claude.com/claude-code)