### PR TITLE
fix: clarify ticket terminology and add image purge option

### DIFF
--- a/platform-bootstrap/.env.example
+++ b/platform-bootstrap/.env.example
@@ -11,16 +11,25 @@ COMPANY_DOMAIN=COMPANY.COM
 
 # Kerberos ticket cache location
 # Your organization may use different locations/formats:
-#   - FILE:/tmp/krb5cc_1000              (standard file)
-#   - DIR::/home/user/.krb5-cache/dev    (directory collection)
-#   - KCM:                                (kernel keyring)
 #
-# Set this to match your 'klist' output:
+# FILE format (single file):
+#   Ticket cache: FILE:/tmp/krb5cc_1000
+#   KERBEROS_CACHE_TYPE=FILE
+#   KERBEROS_CACHE_PATH=/tmp
+#   KERBEROS_CACHE_TICKET=krb5cc_1000
+#
+# DIR format (directory collection):
+#   Ticket cache: DIR::/home/user/.krb5-cache/dev/tkt
+#   KERBEROS_CACHE_TYPE=DIR
+#   KERBEROS_CACHE_PATH=${HOME}/.krb5-cache
+#   KERBEROS_CACHE_TICKET=dev  (subdirectory containing tickets, NOT ticket filename)
+#
+# The sidecar searches in CACHE_PATH/CACHE_TICKET/* for current tickets
+
+# Configuration (adjust based on 'klist' output):
 KERBEROS_CACHE_TYPE=DIR
 KERBEROS_CACHE_PATH=${HOME}/.krb5-cache
-
-# For DIR type, specify the ticket file within the directory
-KERBEROS_CACHE_TICKET=dev/tkt
+KERBEROS_CACHE_TICKET=dev
 
 # ==========================================
 # Note: Local Registry Removed

--- a/platform-bootstrap/Makefile
+++ b/platform-bootstrap/Makefile
@@ -210,10 +210,12 @@ debug-logs: ## Show logs from all platform services
 # Cleanup
 # ==========================================
 
-clean: platform-stop ## Clean up all platform services and volumes
+clean: platform-stop ## Clean up platform services and volumes (keeps images)
 	@echo "Cleaning up platform services..."
-	@docker volume rm platform_kerberos_cache 2>/dev/null || true
-	@echo "✓ Cleanup complete"
+	@echo "1" | ./clean-slate.sh || true
+
+clean-slate: ## Interactive cleanup (option to remove built images too)
+	@./clean-slate.sh
 
 reset: clean ## Reset everything to fresh state
 	@echo "Resetting platform..."

--- a/platform-bootstrap/clean-slate.sh
+++ b/platform-bootstrap/clean-slate.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Clean Slate - Remove all platform Docker resources
+# ===================================================
+# Use this when you want to start fresh with a clean environment
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+echo "🧹 Clean Slate - Platform Docker Cleanup"
+echo "========================================="
+echo ""
+echo -e "${YELLOW}This will remove:${NC}"
+echo "  • Kerberos sidecar container"
+echo "  • Mock services containers"
+echo "  • platform_kerberos_cache volume"
+echo "  • platform_network"
+echo ""
+echo -e "${YELLOW}Options:${NC}"
+echo "  1. Clean resources only (keep built images)"
+echo "  2. Full clean (also remove built images - forces rebuild)"
+echo ""
+
+read -p "Choose [1-2, default 1]: " -n 1 -r cleanup_level
+echo
+cleanup_level=${cleanup_level:-1}
+
+REMOVE_IMAGES=false
+if [ "$cleanup_level" = "2" ]; then
+    REMOVE_IMAGES=true
+    echo ""
+    echo -e "${YELLOW}Full clean selected - will also remove:${NC}"
+    echo "  • platform/kerberos-sidecar:latest image"
+    echo "  • This forces a complete rebuild next time"
+    echo ""
+fi
+
+echo -e "${GREEN}Preserved:${NC}"
+echo "  • Your .env configuration"
+echo "  • Your Kerberos tickets on host"
+if [ "$REMOVE_IMAGES" = false ]; then
+    echo "  • Built sidecar image (reusable)"
+fi
+echo ""
+
+read -p "Continue? [y/N]: " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Cancelled"
+    exit 0
+fi
+
+echo ""
+echo "Stopping and removing containers..."
+
+# Stop services
+docker compose down 2>/dev/null || echo "  (no services to stop)"
+docker compose -f docker-compose.mock-services.yml down 2>/dev/null || echo "  (no mock services)"
+
+# Remove specific containers by name
+docker rm -f kerberos-platform-service 2>/dev/null || echo "  kerberos-platform-service: not found"
+docker rm -f mock-delinea 2>/dev/null || echo "  mock-delinea: not found"
+
+echo ""
+echo "Removing Docker resources..."
+
+# Remove volume
+if docker volume rm platform_kerberos_cache 2>/dev/null; then
+    echo -e "${GREEN}✓${NC} Removed platform_kerberos_cache volume"
+else
+    echo "  platform_kerberos_cache: not found or in use"
+fi
+
+# Remove network
+if docker network rm platform_network 2>/dev/null; then
+    echo -e "${GREEN}✓${NC} Removed platform_network"
+else
+    echo "  platform_network: not found or in use"
+fi
+
+echo ""
+
+# Remove built images if requested
+if [ "$REMOVE_IMAGES" = true ]; then
+    echo "Removing built images..."
+
+    if docker rmi platform/kerberos-sidecar:latest 2>/dev/null; then
+        echo -e "${GREEN}✓${NC} Removed platform/kerberos-sidecar:latest"
+    else
+        echo "  platform/kerberos-sidecar:latest: not found"
+    fi
+
+    echo ""
+fi
+
+echo -e "${GREEN}✓ Clean slate complete!${NC}"
+echo ""
+
+if [ "$REMOVE_IMAGES" = true ]; then
+    echo "Full clean completed. Next run will rebuild sidecar image."
+else
+    echo "Resources cleaned. Built images preserved for faster restart."
+fi
+
+echo ""
+echo "To set up again:"
+echo "  make kerberos-setup"
+echo ""
+echo "Your configuration is preserved in:"
+echo "  platform-bootstrap/.env"

--- a/platform-bootstrap/diagnose-kerberos.sh
+++ b/platform-bootstrap/diagnose-kerberos.sh
@@ -111,13 +111,16 @@ if command -v klist >/dev/null 2>&1; then
                 DETECTED_CACHE_TICKET="$(basename "$TICKET_DIR")"
 
                 echo "  Type: DIR (collection)"
-                echo "  Current ticket: $FULL_PATH"
-                echo -e "  ${GREEN}✓ Ticket file exists${NC}"
+                echo "  Current ticket file: $FULL_PATH"
+                echo -e "  ${GREEN}✓ Ticket exists${NC}"
                 echo ""
-                echo "  Configuration (points to directory, not specific ticket):"
-                echo "    Base directory: $DETECTED_CACHE_PATH"
-                echo "    Subdirectory with tickets: $DETECTED_CACHE_TICKET"
-                echo "    (Sidecar will find active tickets in this directory automatically)"
+                echo "  ${BLUE}Configuration for .env:${NC}"
+                echo "    KERBEROS_CACHE_PATH:   $DETECTED_CACHE_PATH  (base directory)"
+                echo "    KERBEROS_CACHE_TICKET: $DETECTED_CACHE_TICKET  (subdirectory - NOT ticket filename)"
+                echo ""
+                echo "  ${BLUE}How it works:${NC}"
+                echo "    Sidecar searches: \$CACHE_PATH/\$CACHE_TICKET/* for active tickets"
+                echo "    Current ticket 'tkt' found automatically in '$DETECTED_CACHE_TICKET/' directory"
 
             elif [ -d "$FULL_PATH" ]; then
                 # Path is a directory, need to find ticket inside

--- a/platform-bootstrap/kerberos-sidecar/Makefile
+++ b/platform-bootstrap/kerberos-sidecar/Makefile
@@ -25,9 +25,9 @@ check-requirements: ## Check build requirements before building
 
 build: check-requirements ## Build sidecar image for local development
 	@echo "Building Kerberos sidecar image..."
-	@echo "Configuration:"
-	@echo "  Base image: ${IMAGE_ALPINE:-alpine:3.19} (public default)"
-	@echo "  ODBC source: ${ODBC_DRIVER_URL:-Microsoft download} (public default)"
+	@echo -e "Configuration:"
+	@echo -e "  Base image: ${IMAGE_ALPINE:-alpine:3.19} (public default)"
+	@echo -e "  ODBC source: ${ODBC_DRIVER_URL:-Microsoft download} (public default)"
 	docker build \
 		$(if $(IMAGE_ALPINE),--build-arg IMAGE_ALPINE=$(IMAGE_ALPINE),) \
 		$(if $(ODBC_DRIVER_URL),--build-arg ODBC_DRIVER_URL=$(ODBC_DRIVER_URL),) \

--- a/platform-bootstrap/setup-kerberos.sh
+++ b/platform-bootstrap/setup-kerberos.sh
@@ -462,9 +462,14 @@ step_5_detect_ticket_location() {
             echo ""
             print_success "Ticket location detected successfully!"
             echo ""
-            echo -e "  Type:   ${CYAN}$DETECTED_CACHE_TYPE${NC}"
-            echo -e "  Path:   ${CYAN}$DETECTED_CACHE_PATH${NC}"
-            echo -e "  Ticket: ${CYAN}$DETECTED_CACHE_TICKET${NC}"
+            echo -e "  ${BLUE}Configuration Values:${NC}"
+            echo -e "    Type:      ${CYAN}$DETECTED_CACHE_TYPE${NC}"
+            echo -e "    Base path: ${CYAN}$DETECTED_CACHE_PATH${NC}"
+            if [ "$DETECTED_CACHE_TYPE" = "DIR" ]; then
+                echo -e "    Subdir:    ${CYAN}$DETECTED_CACHE_TICKET${NC} (directory containing tickets)"
+            else
+                echo -e "    Filename:  ${CYAN}$DETECTED_CACHE_TICKET${NC}"
+            fi
 
             save_state
             return 0
@@ -846,15 +851,19 @@ step_9_start_services() {
     echo -n "Creating platform_network... "
     if docker network create platform_network 2>/dev/null; then
         print_success "Created"
-    else
+    elif docker network ls | grep -q "platform_network"; then
         print_info "Already exists"
+    else
+        print_warning "Failed to create (may already exist from previous setup)"
     fi
 
     echo -n "Creating platform_kerberos_cache volume... "
     if docker volume create platform_kerberos_cache 2>/dev/null; then
         print_success "Created"
-    else
+    elif docker volume ls | grep -q "platform_kerberos_cache"; then
         print_info "Already exists"
+    else
+        print_warning "Failed to create"
     fi
 
     echo ""


### PR DESCRIPTION
## Summary

Fixes terminology confusion and adds clean-slate helper with optional image purge.

## Terminology Fixes

**Problem:** KERBEROS_CACHE_TICKET was confusing
- For DIR format: It's a subdirectory name (not ticket filename)
- Users saw "dev" and thought it was the ticket (actually it's "tkt")

**Solution:**
1. **.env.example** - Clear examples for both formats:
   ```
   DIR: CACHE_TICKET=dev (subdirectory, NOT filename)
   FILE: CACHE_TICKET=krb5cc_1000 (actual filename)
   ```

2. **diagnose-kerberos.sh** - Better labeling:
   ```
   KERBEROS_CACHE_TICKET: dev (subdirectory - NOT ticket filename)
   How it works: Sidecar searches $CACHE_PATH/$CACHE_TICKET/*
   ```

3. **setup-kerberos.sh Step 5** - Context-aware display:
   - DIR: "Subdir: dev (directory containing tickets)"
   - FILE: "Filename: krb5cc_1000"

## Clean Slate Improvements

**New: clean-slate.sh with purge option**

Interactive cleanup with 2 modes:
1. **Clean resources only** (default)
   - Removes containers, volumes, networks
   - Keeps built images (fast restart)

2. **Full clean (purge)**
   - Also removes platform/kerberos-sidecar:latest
   - Forces fresh rebuild
   - Use when troubleshooting malformed images

**Makefile:**
- `make clean` - Non-interactive, keeps images
- `make clean-slate` - Interactive with purge option

## Minor Fixes

- sidecar Makefile: echo -e for color codes
- Step 9: Better network exists handling
- All terminology consistent throughout

## Benefits

✅ Clear what KERBEROS_CACHE_TICKET means  
✅ Can force fresh build when troubleshooting  
✅ Fast cleanup vs full purge options  
✅ No terminal confusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>