### PR TITLE
fix: clarify labels, add config migration, and fix color codes

### DIFF
--- a/platform-bootstrap/diagnose-kerberos.sh
+++ b/platform-bootstrap/diagnose-kerberos.sh
@@ -70,10 +70,11 @@ if command -v klist >/dev/null 2>&1; then
             DETECTED_DOMAIN=$(echo "$PRINCIPAL" | sed 's/.*@//')
         fi
 
-        # Extract ticket cache location
+        # Extract ticket cache info from klist
         TICKET_CACHE=$(klist 2>/dev/null | grep "Ticket cache:" | sed 's/Ticket cache: //')
         echo ""
-        echo "📍 Ticket cache location: $TICKET_CACHE"
+        echo -e "${BLUE}klist output:${NC} $TICKET_CACHE"
+        echo -e "  (This shows the format and full path from Kerberos)"
 
         # Parse different ticket cache formats and extract base directory
         DETECTED_TICKET_DIR=""


### PR DESCRIPTION
## Summary

Fixes confusing labels, adds migration from old config, and eliminates remaining color code issues.

## Changes

### 1. Clearer Labels ✅
**Before:** "Ticket cache location: DIR::/home/.../.krb5-cache/dev/tkt"  
**After:** "klist output: DIR::/home/.../.krb5-cache/dev/tkt"
- Explains this is what klist reports (format + full path)
- Not confusing about whether it's cache or ticket

### 2. Config Migration ✅
Step 6 now detects old 3-variable configuration:
```
Found old 3-variable configuration (needs migration):
  OLD: KERBEROS_CACHE_TYPE=DIR
  OLD: KERBEROS_CACHE_PATH=${HOME}/.krb5-cache
  OLD: KERBEROS_CACHE_TICKET=dev

Replace old 3-variable config with new single variable? [Y/n]
```
Smooth upgrade path from previous versions.

### 3. Remaining Color Codes Fixed ✅
Step 10 error messages had literal `\033` codes - all fixed with echo -e.

## Benefits

✅ Clear labels (not confusing)
✅ Detects and migrates old config
✅ All color codes render
✅ Smooth upgrade experience

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>