### PR TITLE
feat: add TICKET_MODE for unified local/production sidecar

### DIFF
--- a/platform-bootstrap/.env.example
+++ b/platform-bootstrap/.env.example
@@ -26,6 +26,13 @@ COMPANY_DOMAIN=COMPANY.COM
 # Configuration:
 KERBEROS_TICKET_DIR=${HOME}/.krb5-cache
 
+# Ticket mode (how sidecar gets tickets):
+# - copy: Copies your existing kinit tickets from host (LOCAL DEVELOPMENT)
+# - create: Creates tickets via password/keytab (PRODUCTION/K8S)
+#
+# For local development, use 'copy' - no password needed!
+TICKET_MODE=copy
+
 # ==========================================
 # Note: Local Registry Removed
 # ==========================================

--- a/platform-bootstrap/ARCHITECTURE-KERBEROS-MODES.md
+++ b/platform-bootstrap/ARCHITECTURE-KERBEROS-MODES.md
@@ -1,0 +1,175 @@
+# Kerberos Sidecar Architecture: Two Modes, One Implementation
+
+## Overview
+
+The Kerberos sidecar supports **two modes** with a single unified implementation:
+- **COPY mode** - Local development (copies your kinit tickets)
+- **CREATE mode** - Production/K8s (creates tickets via keytab/password)
+
+## Mode Selection
+
+Set via environment variable: `TICKET_MODE=copy` or `TICKET_MODE=create`
+
+### Local Development (COPY mode)
+
+**Use when:**
+- Developer workstation (WSL2, Mac, Linux)
+- You run `kinit` to get tickets
+- No passwords should touch the ground
+- Testing locally before K8s deployment
+
+**How it works:**
+```yaml
+environment:
+  TICKET_MODE: copy
+volumes:
+  - ${KERBEROS_TICKET_DIR}:/host/tickets:ro  # Your kinit tickets
+  - platform_kerberos_cache:/krb5/cache:rw   # Shared with other services
+```
+
+Sidecar:
+1. Searches `/host/tickets` recursively for ticket files
+2. Copies most recent valid ticket to `/krb5/cache/krb5cc`
+3. Refreshes every 5 minutes (COPY_INTERVAL)
+4. NO password or keytab needed
+
+### Production/K8s (CREATE mode)
+
+**Use when:**
+- Kubernetes pods
+- CI/CD pipelines
+- Service accounts with keytabs
+- No human kinit available
+
+**How it works:**
+```yaml
+environment:
+  TICKET_MODE: create
+  KRB_PRINCIPAL: svc_airflow@COMPANY.COM
+  KRB_KEYTAB_PATH: /krb5/keytabs/airflow.keytab
+volumes:
+  - keytab-secret:/krb5/keytabs:ro
+  - kerberos-cache:/krb5/cache:rw
+```
+
+Sidecar:
+1. Creates tickets via `kinit -kt` (keytab) or `kinit` (password)
+2. Renews before expiration
+3. Logs errors if can't obtain
+4. Requires keytab file or password
+
+## Multiple Service Support
+
+**One sidecar serves ALL services:**
+
+```yaml
+services:
+  # ONE sidecar (either mode)
+  kerberos-sidecar:
+    environment:
+      TICKET_MODE: copy  # or create
+    volumes:
+      - platform_kerberos_cache:/krb5/cache:rw
+
+  # MULTIPLE consumers
+  airflow-scheduler:
+    volumes:
+      - platform_kerberos_cache:/krb5/cache:ro
+    environment:
+      - KRB5CCNAME=/krb5/cache/krb5cc
+
+  airflow-webserver:
+    volumes:
+      - platform_kerberos_cache:/krb5/cache:ro
+    environment:
+      - KRB5CCNAME=/krb5/cache/krb5cc
+
+  openmetadata:
+    volumes:
+      - platform_kerberos_cache:/krb5/cache:ro
+    environment:
+      - KRB5CCNAME=/krb5/cache/krb5cc
+
+  # Any other service needing Kerberos...
+```
+
+**Benefits:**
+- ✅ One sidecar for everything
+- ✅ Airflow, OpenMetadata, custom services all share tickets
+- ✅ Sidecar doesn't care about consumers
+- ✅ Add new services by just mounting volume
+
+## Configuration Examples
+
+### Local Development (.env)
+```bash
+COMPANY_DOMAIN=MYCOMPANY.COM
+KERBEROS_TICKET_DIR=${HOME}/.krb5-cache
+TICKET_MODE=copy
+```
+
+### Production (K8s ConfigMap)
+```yaml
+COMPANY_DOMAIN: MYCOMPANY.COM
+TICKET_MODE: create
+KRB_PRINCIPAL: svc_airflow@MYCOMPANY.COM
+KRB_KEYTAB_PATH: /krb5/keytabs/airflow.keytab
+```
+
+## Workflow
+
+### Local Development
+```bash
+# 1. Get your ticket (normal workflow)
+kinit you@COMPANY.COM
+
+# 2. Start platform
+make platform-start
+
+# Sidecar automatically:
+# - Finds your ticket in KERBEROS_TICKET_DIR
+# - Copies to shared volume
+# - Refreshes every 5 minutes
+# - All containers get Kerberos access
+```
+
+### Production/K8s
+```bash
+# 1. Create keytab secret (one time)
+kubectl create secret generic airflow-keytab --from-file=airflow.keytab
+
+# 2. Deploy with TICKET_MODE=create
+# Sidecar automatically:
+# - Creates tickets from keytab
+# - Renews before expiration
+# - All pods get Kerberos access
+```
+
+## Why This Design
+
+**Same sidecar everywhere:**
+- ✅ Test locally with copy mode
+- ✅ Deploy to K8s with create mode
+- ✅ One implementation, two behaviors
+
+**Security:**
+- ✅ Local: No passwords in config (uses your kinit)
+- ✅ Production: Keytab in K8s secrets (secure)
+- ✅ Passwords never in .env files
+
+**Flexibility:**
+- ✅ Works with any service needing Kerberos
+- ✅ Airflow, OpenMetadata, custom tools
+- ✅ Just mount the volume
+
+## Troubleshooting
+
+**Local dev - "No tickets found":**
+- Check: `klist` (do you have tickets?)
+- Check: KERBEROS_TICKET_DIR matches `klist` output
+- Check: `docker logs kerberos-platform-service`
+
+**Production - "Ticket acquisition failed":**
+- Check: Keytab file exists and is mounted
+- Check: KRB_PRINCIPAL matches keytab
+- Check: `docker logs sidecar`

--- a/platform-bootstrap/docker-compose.yml
+++ b/platform-bootstrap/docker-compose.yml
@@ -13,21 +13,25 @@ services:
     restart: unless-stopped
 
     environment:
+      # Ticket mode: copy (local dev) or create (production)
+      # - copy: Copies your existing kinit tickets from host
+      # - create: Creates tickets via password/keytab
+      TICKET_MODE: ${TICKET_MODE:-copy}
+
       # Developer mode configuration
       ENVIRONMENT: development
       KRB_PRINCIPAL: ${USER}@${COMPANY_DOMAIN}
       KRB_REALM: ${COMPANY_DOMAIN}
 
-      # Use password auth for developers (keytab in production)
-      USE_PASSWORD: "true"
-      KRB_PASSWORD_COMMAND: "cat /run/secrets/krb_password"
+      # Copy mode refreshes tickets from host every 5 minutes
+      # (No password or keytab needed for local development)
+      COPY_INTERVAL: ${COPY_INTERVAL:-300}
 
-      # More frequent renewal for development
-      RENEWAL_INTERVAL: 1800  # 30 minutes
-
-      # Mount existing developer ticket if available
-      IMPORT_EXISTING_TICKET: "true"
-      HOST_TICKET_PATH: ${HOME}/.krb5_cache/krbtgt_${COMPANY_DOMAIN}
+      # Create mode settings (for production/K8s)
+      # Uncomment when using TICKET_MODE=create:
+      # USE_PASSWORD: "true"
+      # KRB_PASSWORD_COMMAND: "cat /run/secrets/krb_password"
+      # RENEWAL_INTERVAL: 1800
 
     volumes:
       # Share ticket cache with all local containers
@@ -70,6 +74,7 @@ services:
 volumes:
   kerberos_cache:
     name: platform_kerberos_cache
+    external: true
 
 networks:
   platform-net:


### PR DESCRIPTION
## Summary

Adds TICKET_MODE to fix local dev (copies kinit tickets) and support production (creates via keytab).

## Problem

Sidecar tried to CREATE tickets with password when it should COPY your kinit tickets.

## Solution

TICKET_MODE=copy (local) or create (production)

**Local:** Copies your tickets, no password  
**Production:** Creates via keytab  
**Multiple services:** One sidecar for Airflow + OpenMetadata + more

Fixes Step 10 failure!

🤖 Generated with [Claude Code](https://claude.com/claude-code)