### PR TITLE
feat: use BuildKit secrets for .netrc authentication

### DIFF
--- a/platform-bootstrap/kerberos-sidecar/Dockerfile.test-image
+++ b/platform-bootstrap/kerberos-sidecar/Dockerfile.test-image
@@ -21,6 +21,7 @@ ARG PIP_TRUSTED_HOST
 RUN pip install --no-cache-dir uv
 
 # Configure UV/pip for corporate environment if provided
+# Build args contain index URL detected from host uv.toml/pip.conf
 RUN if [ -n "$PIP_INDEX_URL" ]; then \
         echo "Configuring for corporate PyPI: $PIP_INDEX_URL" && \
         uv pip config set global.index-url "$PIP_INDEX_URL" 2>/dev/null || \
@@ -32,9 +33,13 @@ RUN if [ -n "$PIP_INDEX_URL" ]; then \
         pip config set global.trusted-host "$PIP_TRUSTED_HOST"; \
     fi
 
-# Install Python packages using UV (much faster than pip)
-# Will use corporate PyPI if configured via build args
-RUN uv pip install --system --no-cache pyodbc
+# Install Python packages using UV with BuildKit secret for credentials
+# The .netrc file is mounted temporarily (NOT stored in image)
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    uv pip install --system --no-cache pyodbc
+
+# Credentials are NOT in the final image - only used during build
+# Verify: docker run --rm platform/kerberos-test:latest cat /root/.netrc (will fail)
 
 # Set working directory
 WORKDIR /app

--- a/platform-bootstrap/kerberos-sidecar/Makefile
+++ b/platform-bootstrap/kerberos-sidecar/Makefile
@@ -62,15 +62,29 @@ build-test-image: ## Build SQL Server test image with pyodbc pre-installed
 		echo "  For corporate: Configure ~/.config/uv/uv.toml or ~/.pip/pip.conf"; \
 	fi; \
 	echo ""; \
-	docker build \
-		-f Dockerfile.test-image \
-		$(if $(IMAGE_PYTHON),--build-arg IMAGE_PYTHON=$(IMAGE_PYTHON),) \
-		--build-arg PIP_INDEX_URL=$$PIP_INDEX_URL \
-		--build-arg PIP_TRUSTED_HOST=$$PIP_TRUSTED_HOST \
-		-t platform/kerberos-test:latest .
+	if [ -f "${HOME}/.netrc" ]; then \
+		echo "  Using credentials from ~/.netrc (via BuildKit secret)"; \
+		echo "  (Credentials NOT stored in image - only used during build)"; \
+		docker build \
+			-f Dockerfile.test-image \
+			$(if $(IMAGE_PYTHON),--build-arg IMAGE_PYTHON=$(IMAGE_PYTHON),) \
+			--build-arg PIP_INDEX_URL=$$PIP_INDEX_URL \
+			--build-arg PIP_TRUSTED_HOST=$$PIP_TRUSTED_HOST \
+			--secret id=netrc,src=${HOME}/.netrc \
+			-t platform/kerberos-test:latest .; \
+	else \
+		echo "  No ~/.netrc found - build may fail if PyPI requires auth"; \
+		docker build \
+			-f Dockerfile.test-image \
+			$(if $(IMAGE_PYTHON),--build-arg IMAGE_PYTHON=$(IMAGE_PYTHON),) \
+			--build-arg PIP_INDEX_URL=$$PIP_INDEX_URL \
+			--build-arg PIP_TRUSTED_HOST=$$PIP_TRUSTED_HOST \
+			-t platform/kerberos-test:latest .; \
+	fi
 	@echo "✓ Built: platform/kerberos-test:latest"
 	@echo ""
 	@echo "This image uses UV for fast package installation"
+	@echo "Credentials from .netrc were used during build but NOT stored in image"
 
 test: ## Test sidecar image locally
 	@echo "Testing sidecar image..."


### PR DESCRIPTION
## Summary

Uses Docker BuildKit secrets to mount .netrc during build (credentials NOT stored in image).

## Problem

Test image build failed with "User for {netloc}:" password prompt because:
- UV/pip found corporate index URL
- No credentials available in build context
- .bashrc not sourced, env vars not inherited

## Solution

BuildKit --secret mounts .netrc temporarily:
- Available during build only
- NOT stored in image layers
- NOT in docker history
- Safe to push to registry

## Changes

**Dockerfile.test-image:**
```dockerfile
RUN --mount=type=secret,id=netrc,target=/root/.netrc \
    uv pip install --system pyodbc
```

**Makefile:**
```bash
docker build --secret id=netrc,src=${HOME}/.netrc ...
```

## Security Verification

After build:
```bash
docker run --rm platform/kerberos-test:latest cat /root/.netrc
# cat: No such file or directory ✓
```

## Benefits

✅ Corporate PyPI authentication works
✅ Credentials never stored in image
✅ Safe to push to registry
✅ Standard Docker BuildKit pattern

Perfect for corporate environments with .netrc!

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>