### PR TITLE
fix: mount .netrc for ALL pip operations including UV install

### DIFF
--- a/docs/building-images-corporate.md
+++ b/docs/building-images-corporate.md
@@ -1,0 +1,78 @@
+# Building Docker Images in Corporate Environments
+
+Quick reference for building images when public registries are blocked.
+
+## Key Principles
+
+1. **Base images:** Use `ARG IMAGE_*` variables from .env
+2. **Package installs (apk/apt):** Usually work via package mirrors (or use base from Artifactory)
+3. **Python packages (pip/uv):** Need credentials + index URL
+4. **Binary downloads (curl):** May need Artifactory mirrors
+
+## Python Package Installation Pattern
+
+### The Problem
+Corporate environments block public PyPI. Your machine works because:
+- `~/.config/uv/uv.toml` or `~/.pip/pip.conf` → index URL
+- `~/.netrc` or env vars → credentials
+
+**But Docker build has NONE of these!**
+
+### The Solution (3 steps)
+
+**1. Auto-detect index from host:**
+```makefile
+# Makefile
+AUTO_INDEX=$(python3 -c "import tomllib; ..." 2>/dev/null)
+docker build --build-arg PIP_INDEX_URL=$$AUTO_INDEX ...
+```
+
+**2. Mount .netrc as BuildKit secret:**
+```bash
+docker build --secret id=netrc,src=${HOME}/.netrc ...
+```
+
+**3. Use in single RUN with .netrc mounted:**
+```dockerfile
+ARG PIP_INDEX_URL
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    pip config set global.index-url "$PIP_INDEX_URL" && \
+    pip install uv && \
+    uv pip install your-package
+```
+
+**Why single RUN:** .netrc needed for ALL pip operations (including installing UV itself)
+
+## Example: kerberos-sidecar/Dockerfile.test-image
+
+See `platform-bootstrap/kerberos-sidecar/Dockerfile.test-image` for complete working example.
+
+**Build:**
+```bash
+cd platform-bootstrap/kerberos-sidecar
+make build-test-image  # Auto-detects everything
+```
+
+## Corporate Checklist
+
+Before building images:
+- [ ] Configure `~/.config/uv/uv.toml` or `~/.pip/pip.conf` (index URL)
+- [ ] Configure `~/.netrc` (credentials)
+- [ ] Set `IMAGE_*` variables in .env (base images)
+- [ ] Run `docker login` for Artifactory (Docker images)
+
+Then all builds "just work"!
+
+## Troubleshooting
+
+**"User for {artifactory}: " prompt:**
+- Missing .netrc credentials
+- Check: `cat ~/.netrc` has `machine artifactory.company.com`
+
+**"SSL: UNEXPECTED_EOF":**
+- Corporate firewall blocking
+- Need Artifactory mirror for that package source
+
+**"pip install uv" fails:**
+- Corporate Python image pre-configured for corporate PyPI
+- Need .netrc mounted in SAME RUN as `pip install uv`

--- a/platform-bootstrap/kerberos-sidecar/Dockerfile.test-image
+++ b/platform-bootstrap/kerberos-sidecar/Dockerfile.test-image
@@ -17,25 +17,24 @@ RUN apk add --no-cache \
 ARG PIP_INDEX_URL
 ARG PIP_TRUSTED_HOST
 
-# Install UV (fast Python package installer)
-RUN pip install --no-cache-dir uv
-
-# Configure UV/pip for corporate environment if provided
-# Build args contain index URL detected from host uv.toml/pip.conf
-RUN if [ -n "$PIP_INDEX_URL" ]; then \
+# Install UV and pyodbc in single RUN with .netrc mounted throughout
+# The .netrc file is mounted temporarily (NOT stored in image)
+# This provides credentials for BOTH installing UV and installing pyodbc
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    # Configure pip/uv for corporate environment if provided \
+    if [ -n "$PIP_INDEX_URL" ]; then \
         echo "Configuring for corporate PyPI: $PIP_INDEX_URL" && \
-        uv pip config set global.index-url "$PIP_INDEX_URL" 2>/dev/null || \
         pip config set global.index-url "$PIP_INDEX_URL"; \
     fi && \
     if [ -n "$PIP_TRUSTED_HOST" ]; then \
         echo "Trusted host: $PIP_TRUSTED_HOST" && \
-        uv pip config set global.trusted-host "$PIP_TRUSTED_HOST" 2>/dev/null || \
         pip config set global.trusted-host "$PIP_TRUSTED_HOST"; \
-    fi
-
-# Install Python packages using UV with BuildKit secret for credentials
-# The .netrc file is mounted temporarily (NOT stored in image)
-RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    fi && \
+    # Install UV (needs .netrc if corporate PyPI requires auth) \
+    echo "Installing UV package manager..." && \
+    pip install --no-cache-dir uv && \
+    # Install pyodbc using UV (much faster) \
+    echo "Installing pyodbc with UV..." && \
     uv pip install --system --no-cache pyodbc
 
 # Credentials are NOT in the final image - only used during build


### PR DESCRIPTION
## Summary

Fixes UV installation failure by mounting .netrc for ALL package operations.

## Root Cause

UV installation itself needs authentication:
- Corporate Python image pre-configured for corporate PyPI
- `pip install uv` tries corporate PyPI
- .netrc only mounted for pyodbc (too late!)
- UV install failed asking for credentials

## Solution

Single RUN with .netrc throughout:
```dockerfile
RUN --mount=type=secret,id=netrc,target=/root/.netrc \
    pip config set ... && \
    pip install uv && \
    uv pip install pyodbc
```

## Benefits

✅ Works with corporate Python images
✅ .netrc used for ALL installs
✅ Still not stored in image
✅ Cleaner (one RUN layer)

This should fix the build!

🤖 Generated with [Claude Code](https://claude.com/claude-code)