### PR TITLE
fix: use pip instead of UV for test image simplicity

### DIFF
--- a/platform-bootstrap/kerberos-sidecar/Dockerfile.test-image
+++ b/platform-bootstrap/kerberos-sidecar/Dockerfile.test-image
@@ -17,11 +17,11 @@ RUN apk add --no-cache \
 ARG PIP_INDEX_URL
 ARG PIP_TRUSTED_HOST
 
-# Install UV and pyodbc in single RUN with .netrc mounted throughout
+# Install pyodbc with .netrc mounted for authentication
 # The .netrc file is mounted temporarily (NOT stored in image)
-# This provides credentials for BOTH installing UV and installing pyodbc
+# Using pip (not UV) for simplicity - this is just a test image
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \
-    # Configure pip/uv for corporate environment if provided \
+    # Configure pip for corporate environment if provided \
     if [ -n "$PIP_INDEX_URL" ]; then \
         echo "Configuring for corporate PyPI: $PIP_INDEX_URL" && \
         pip config set global.index-url "$PIP_INDEX_URL"; \
@@ -30,12 +30,9 @@ RUN --mount=type=secret,id=netrc,target=/root/.netrc \
         echo "Trusted host: $PIP_TRUSTED_HOST" && \
         pip config set global.trusted-host "$PIP_TRUSTED_HOST"; \
     fi && \
-    # Install UV (needs .netrc if corporate PyPI requires auth) \
-    echo "Installing UV package manager..." && \
-    pip install --no-cache-dir uv && \
-    # Install pyodbc using UV (much faster) \
-    echo "Installing pyodbc with UV..." && \
-    uv pip install --system --no-cache pyodbc
+    # Install pyodbc using pip \
+    echo "Installing pyodbc..." && \
+    pip install --no-cache-dir pyodbc
 
 # Credentials are NOT in the final image - only used during build
 # Verify: docker run --rm platform/kerberos-test:latest cat /root/.netrc (will fail)


### PR DESCRIPTION
## Summary

Simplifies test image by using pip instead of UV.

## Problem

UV installation needs installer script from PyPI - adds complexity and another failure point.

## Solution

Just use pip (already in base Python image):
- Remove UV installation
- Use pip directly for pyodbc
- Still uses .netrc for auth
- Still auto-detects index

## Benefits

✅ Simpler (fewer steps)
✅ Fewer dependencies
✅ Good enough for testing

Note: Layer 1 base can still use UV - this is just test image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)