### PR TITLE
fix: Correct path to diagnose-kerberos.sh in Kerberos setup wizard

### DIFF
--- a/kerberos/setup.sh
+++ b/kerberos/setup.sh
@@ -535,9 +535,9 @@ EOF
     print_info "Running diagnostic to detect ticket location..."
     echo ""
 
-    if [ -f "$PLATFORM_DIR/diagnostics/diagnose-kerberos.sh" ]; then
+    if [ -f "$SCRIPT_DIR/diagnostics/diagnose-kerberos.sh" ]; then
         # Run diagnostic and capture output
-        local diag_output=$("$PLATFORM_DIR/diagnostics/diagnose-kerberos.sh" 2>&1)
+        local diag_output=$("$SCRIPT_DIR/diagnostics/diagnose-kerberos.sh" 2>&1)
 
         # Try to extract configuration from diagnostic output
         DETECTED_TICKET_DIR=$(echo "$diag_output" | grep "^KERBEROS_TICKET_DIR=" | cut -d= -f2)


### PR DESCRIPTION
## Summary

Fixes the "diagnose-kerberos.sh not found" error that occurs during Kerberos setup after running clean-slate.

## Problem

When running Kerberos setup after a clean-slate, on step 5/11 ("Running diagnostic to detect ticket location"), the script fails with:
```
diagnose-kerberos.sh not found
```

This forces users to manually provide the Kerberos ticket directory path, defeating the purpose of automatic detection.

## Root Cause

The `setup.sh` script was looking for `diagnose-kerberos.sh` in the wrong location:
- **Wrong path**: `$PLATFORM_DIR/diagnostics/diagnose-kerberos.sh`
  - Where `$PLATFORM_DIR` = `/home/user/repos/airflow-data-platform` (platform root)
- **Correct path**: `$SCRIPT_DIR/diagnostics/diagnose-kerberos.sh`
  - Where `$SCRIPT_DIR` = `/home/user/repos/airflow-data-platform/kerberos`
  
The diagnostic script is actually located at `kerberos/diagnostics/diagnose-kerberos.sh`.

## Solution

Changed the path references on lines 538 and 540 of `kerberos/setup.sh`:
- From: `$PLATFORM_DIR/diagnostics/diagnose-kerberos.sh`
- To: `$SCRIPT_DIR/diagnostics/diagnose-kerberos.sh`

## Test Plan

```bash
# 1. Clean slate to remove existing setup
make clean-slate

# 2. Run Kerberos setup
cd kerberos
./setup.sh

# 3. Verify step 5/11 now works:
#    - Should show "Running diagnostic to detect ticket location..."
#    - Should automatically detect your ticket directory
#    - Should NOT show "diagnose-kerberos.sh not found"
```

## Impact

This fix ensures the Kerberos setup wizard can properly auto-detect ticket locations, providing a smoother setup experience especially after running clean-slate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>