### PR TITLE
fix: Support Azure DevOps Git URLs with @ character

### DIFF
--- a/wizard/services/pagila/tests/test_validators.py
+++ b/wizard/services/pagila/tests/test_validators.py
@@ -31,6 +31,20 @@ def test_validate_git_url_valid_corporate():
     assert result == "https://git.company.com/repos/pagila.git"
 
 
+def test_validate_git_url_valid_azure_devops():
+    """Accepts valid Azure DevOps URL with @ character"""
+    result = validate_git_url("https://mycorp@dev.azure.com/team_folder/_git/pagila", {})
+    assert isinstance(result, str)
+    assert result == "https://mycorp@dev.azure.com/team_folder/_git/pagila"
+
+
+def test_validate_git_url_valid_azure_devops_with_git():
+    """Accepts valid Azure DevOps URL with .git extension"""
+    result = validate_git_url("https://mycorp@dev.azure.com/team/_git/pagila.git", {})
+    assert isinstance(result, str)
+    assert result == "https://mycorp@dev.azure.com/team/_git/pagila.git"
+
+
 def test_validate_git_url_invalid_empty():
     """Rejects empty URL"""
     with pytest.raises(ValueError, match="cannot be empty"):

--- a/wizard/services/pagila/validators.py
+++ b/wizard/services/pagila/validators.py
@@ -35,8 +35,9 @@ def validate_git_url(value: str, ctx: Dict[str, Any]) -> str:
         raise ValueError("Invalid characters in Git URL")
 
     # Basic URL pattern - should have domain and path
-    # Pattern: https://domain.com/path or https://domain.com/path.git
-    pattern = r'^https://[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(/[a-zA-Z0-9._/-]+(\.git)?)?$'
+    # Pattern: https://[username@]domain.com/path or https://[username@]domain.com/path.git
+    # Supports Azure DevOps format: https://org@dev.azure.com/team/_git/repo
+    pattern = r'^https://([a-zA-Z0-9.-]+@)?[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(/[a-zA-Z0-9._/-]+(\.git)?)?$'
 
     if not re.match(pattern, value):
         raise ValueError("Invalid Git URL format")


### PR DESCRIPTION
## Summary

Fixed Git URL validation to support Azure DevOps URLs with `@` character for organization specification.

## Issue

Corporate user tried to use Azure DevOps URL:
```
https://mycorp@dev.azure.com/team_folder/_git/pagila
```

But got error:
```
Error: Invalid Git URL
```

This is a valid Azure DevOps URL format but was rejected by the validator.

## Root Cause

The Git URL validator regex didn't allow the `@` character:
```python
pattern = r'^https://[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(/[a-zA-Z0-9._/-]+(\.git)?)?$'
```

Azure DevOps uses `org@host` format to specify organization.

## Fix (TDD: RED-GREEN-REFACTOR)

### RED Phase
Added 2 failing tests for Azure DevOps URLs:
- `test_validate_git_url_valid_azure_devops`
- `test_validate_git_url_valid_azure_devops_with_git`

### GREEN Phase
Updated regex to support optional username/org prefix:
```python
pattern = r'^https://([a-zA-Z0-9.-]+@)?[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(/[a-zA-Z0-9._/-]+(\.git)?)?$'
```

The `([a-zA-Z0-9.-]+@)?` makes the `org@` part optional.

### REFACTOR Phase
Verified all 16 Git URL tests pass, including existing formats.

## Files Changed

- `wizard/services/pagila/validators.py` - Updated regex pattern
- `wizard/services/pagila/tests/test_validators.py` - Added 2 new tests

## Test Results

✅ All 16 Git URL validator tests pass

## Supported URL Formats

Before and after fix:
- ✅ GitHub: `https://github.com/user/repo.git`
- ✅ GitLab: `https://gitlab.com/group/repo.git`
- ✅ Corporate Git: `https://git.company.com/repos/repo.git`
- ✅ Azure DevOps: `https://org@dev.azure.com/team/_git/repo` **(NEW)**

## Breaking Changes

None - all existing URL formats continue to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>