### PR TITLE
fix: Clean-slate now properly removes all Pagila containers and orpha…

### DIFF
--- a/wizard/engine/schema.py
+++ b/wizard/engine/schema.py
@@ -61,4 +61,5 @@ class Flow(BaseModel):
     service_selection: List[Step] = Field(default_factory=list, description="Steps for selecting services")
     targets: List[Dict[str, Any]] = Field(default_factory=list, description="Services to include in flow")
     glue: Optional[List[Dict[str, Any]]] = Field(None, description="Cross-service coordination steps")
+    final_cleanup: Optional[List[Step]] = Field(None, description="Final cleanup steps to run after all services")
     policy: Optional[Dict[str, str]] = Field(None, description="Execution policy (ordering, failure handling)")

--- a/wizard/flows/clean-slate.yaml
+++ b/wizard/flows/clean-slate.yaml
@@ -123,6 +123,13 @@ targets:
     enabled: false
     depends_on: []  # Postgres torn down LAST (no dependencies in teardown)
 
+# Final cleanup - runs AFTER all services are torn down
+final_cleanup:
+  - id: cleanup_orphaned_resources
+    type: action
+    action: discovery.cleanup_orphaned_resources
+    next: null
+
 # Execution policy
 policy:
   ordering: reverse-topological  # Teardown order is REVERSE of setup

--- a/wizard/services/pagila/teardown-spec.yaml
+++ b/wizard/services/pagila/teardown-spec.yaml
@@ -15,7 +15,7 @@ steps:
 
   - id: stop_service
     type: action
-    action: pagila.stop_service
+    action: pagila.teardown.stop_service
     next: pagila_remove_images_question
 
   - id: pagila_remove_images_question

--- a/wizard/services/pagila/teardown_actions.py
+++ b/wizard/services/pagila/teardown_actions.py
@@ -4,7 +4,11 @@ from typing import Dict, Any
 
 
 def stop_service(ctx: Dict[str, Any], runner) -> None:
-    """Stop Pagila service (no-op as Pagila has no dedicated service).
+    """Stop and remove Pagila containers.
+
+    Pagila creates containers:
+    - pagila-postgres: Main PostgreSQL container for Pagila
+    - pagila-jsonb-restore: Container created by docker-compose for data restoration
 
     Args:
         ctx: Context dictionary
@@ -13,9 +17,13 @@ def stop_service(ctx: Dict[str, Any], runner) -> None:
     Returns:
         None
     """
-    # Pagila doesn't have a dedicated service to stop
-    # This is a no-op for uniform interface
-    pass
+    # Remove all pagila-related containers
+    containers = ['pagila-postgres', 'pagila-jsonb-restore', 'pagila']  # Include legacy 'pagila' name
+
+    for container in containers:
+        command = ['docker', 'rm', '-f', container]
+        # Use runner.run_shell with error suppression (container might not exist)
+        runner.run_shell(command)
 
 
 def drop_database(ctx: Dict[str, Any], runner) -> None:


### PR DESCRIPTION
…ned Docker resources

- Fixed Pagila discovery to detect pagila-postgres and pagila-jsonb-restore containers
- Fixed Pagila teardown to actually remove containers (stop_service was no-op)
- Fixed action name mismatch in teardown-spec.yaml (pagila.stop_service -> pagila.teardown.stop_service)
- Added final_cleanup phase to remove dangling images and anonymous volumes
- Clean-slate now removes ALL Docker artifacts leaving system completely clean

Previously: Clean-slate left behind Pagila containers, dangling images, and anonymous volumes
Now: Clean-slate removes everything - containers, images, and volumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)