### PR TITLE
feat: Add auth-restricted prebuilt image test scenarios

### DIFF
--- a/TEST-IMAGES.md
+++ b/TEST-IMAGES.md
@@ -1,0 +1,173 @@
+# Test Images Documentation
+
+## Overview
+
+This document describes the test image system used to validate the platform installer's ability to handle complex corporate Docker registry naming conventions. The system ensures we can always recreate and test with the exact same complex image paths that customers use in enterprise environments.
+
+## Quick Start
+
+```bash
+# Check what test images exist
+./mock-corporate-image.py test-status
+
+# Create all test images
+./mock-corporate-image.py test-setup
+
+# Remove all test images
+./mock-corporate-image.py test-teardown
+```
+
+## Test Image Configuration
+
+All test images are defined in `test-images.yaml`. This file is version-controlled and contains:
+- The exact complex registry paths to test
+- Source images to use
+- Build instructions for prebuilt images
+- Test scenarios and validation steps
+
+## Key Test Cases
+
+### 1. Complex PostgreSQL Corporate Image
+**Image**: `mycorp.jfrog.io/docker-mirror/mycorp-approved-images/postgres/17.5:2025.10.01`
+
+This is our primary test case that simulates:
+- Deep registry path with multiple segments
+- Corporate mirror structure (`docker-mirror/mycorp-approved-images`)
+- Date-based versioning (2025.10.01)
+- JFrog Artifactory registry naming
+
+**Testing Steps**:
+1. Create the mock image: `./mock-corporate-image.py test-setup`
+2. Run the platform installer: `./platform setup`
+3. When prompted for PostgreSQL image, enter the full corporate path
+4. Verify it's saved in `platform-bootstrap/.env`
+5. Re-run setup to verify persistence
+6. Run `./platform clean-slate` to verify removal
+
+### 2. PostgreSQL with Port Number
+**Image**: `internal.artifactory.company.com:8443/docker-prod/postgres/17.5:v2025.10-hardened`
+
+Tests handling of:
+- Registry URLs with explicit port numbers
+- "Hardened" image tags
+- Internal company domains
+
+### 3. Prebuilt Kerberos Images
+**Ubuntu**: `mycorp.jfrog.io/platform/kerberos-sidecar:ubuntu-22.04-prebuilt`
+**Debian**: `company.registry.io:5000/security/kerberos/debian:12-slim-krb5-v1.20`
+
+These test:
+- Prebuilt images with packages already installed
+- Different base operating systems
+- Security-specific registry paths
+
+## How It Works
+
+### Persistence
+The `test-images.yaml` file ensures we always have the exact same test configuration:
+- Committed to version control
+- Can be modified to add new test cases
+- Readable by both the mock utility and me (Claude) for consistent recreation
+
+### Recreation Process
+When you need to recreate test images (e.g., after Docker cleanup):
+```bash
+./mock-corporate-image.py test-setup
+```
+
+This command:
+1. Reads `test-images.yaml`
+2. Creates each mock image with the exact specified name
+3. For simple images: tags existing Docker images
+4. For Kerberos: builds images with required packages
+
+### Verification
+Always verify test images before testing:
+```bash
+./mock-corporate-image.py test-status
+```
+
+This shows:
+- Which test images exist
+- Which are missing
+- Image sizes
+- Quick visual status
+
+## Adding New Test Cases
+
+To add a new test case:
+
+1. Edit `test-images.yaml`
+2. Add a new entry under `test_images`:
+```yaml
+  new_test_case:
+    description: "What this tests"
+    type: "tag"  # or "build-kerberos"
+    source_image: "base:image"
+    mock_name: "complex.registry.path/image:tag"
+    use_case: "Why we need this test"
+```
+
+3. Run `./mock-corporate-image.py test-setup` to create it
+
+## Common Test Scenarios
+
+### Before Shipping Features
+Always run these tests before shipping:
+
+```bash
+# 1. Setup test images
+./mock-corporate-image.py test-setup
+
+# 2. Test PostgreSQL custom image persistence
+./platform setup
+# Use: mycorp.jfrog.io/docker-mirror/mycorp-approved-images/postgres/17.5:2025.10.01
+
+# 3. Verify it persists
+./platform setup  # Should remember the custom image
+
+# 4. Test clean-slate removal
+./platform clean-slate  # Should remove the custom image
+
+# 5. Test with Kerberos prebuilt
+./platform setup
+# Enable Kerberos
+# Use: mycorp.jfrog.io/platform/kerberos-sidecar:ubuntu-22.04-prebuilt
+# Select "prebuilt" mode
+
+# 6. Clean up
+./platform clean-slate
+./mock-corporate-image.py test-teardown
+```
+
+## Troubleshooting
+
+### Test images missing after Docker cleanup
+Simply recreate them:
+```bash
+./mock-corporate-image.py test-setup
+```
+
+### Need to verify what's configured
+Check the configuration:
+```bash
+cat test-images.yaml
+```
+
+### Image creation fails
+Check Docker is running and you have the base images:
+```bash
+docker pull postgres:17.5-alpine
+docker pull ubuntu:22.04
+docker pull debian:12-slim
+```
+
+## For Claude
+
+When working on platform installer features, I can always:
+1. Read `test-images.yaml` to see exact test configurations
+2. Use `./mock-corporate-image.py test-setup` to recreate test images
+3. Reference the complex PostgreSQL path: `mycorp.jfrog.io/docker-mirror/mycorp-approved-images/postgres/17.5:2025.10.01`
+4. Test with this exact configuration before any changes are shipped
+
+The test configuration is persistent and version-controlled, ensuring consistent testing across sessions.

--- a/mock-corporate-image.py
+++ b/mock-corporate-image.py
@@ -149,6 +149,127 @@ def remove_mock_image(mock_name):
         print(f"{Colors.RED}Failed to remove image: {stderr}{Colors.RESET}")
         return False
 
+def build_sql_auth_image(mock_name, source_image=None):
+    """Build a SQL auth testing image with Kerberos + Microsoft SQL drivers.
+
+    This builds an image with both Kerberos packages and Microsoft SQL Server
+    drivers for testing SQL authentication scenarios.
+
+    Args:
+        mock_name: The mock corporate registry name to use
+        source_image: The source image to build from (if None, uses default)
+    """
+    # Get source image from config if not provided
+    if source_image is None:
+        source_image = 'alpine:3.19'  # Default to Alpine for SQL auth
+
+    print(f"\n{Colors.BOLD}Building SQL Auth Testing Image{Colors.RESET}")
+    print(f"Base: {Colors.YELLOW}{source_image}{Colors.RESET}")
+    print(f"Target: {Colors.YELLOW}{mock_name}{Colors.RESET}\n")
+
+    # For SQL auth, we currently only support Alpine-based images due to ODBC driver requirements
+    # The Microsoft ODBC drivers for Alpine are specific builds
+    dockerfile_content = f'''FROM {source_image}
+
+# Install Kerberos client libraries and SQL Server ODBC drivers
+RUN apk add --no-cache \\
+    krb5 \\
+    krb5-libs \\
+    krb5-conf \\
+    krb5-dev \\
+    bash \\
+    curl \\
+    gnupg \\
+    unixodbc \\
+    unixodbc-dev \\
+    freetds \\
+    freetds-dev \\
+    python3 \\
+    py3-pip \\
+    gcc \\
+    g++ \\
+    musl-dev \\
+    libffi-dev \\
+    openssl-dev
+
+# Install Microsoft ODBC Driver for SQL Server (Alpine compatible)
+RUN curl -O https://download.microsoft.com/download/3/5/5/355d7943-a338-41a7-858d-53b259ea33f5/msodbcsql18_18.3.2.1-1_amd64.apk && \\
+    curl -O https://download.microsoft.com/download/3/5/5/355d7943-a338-41a7-858d-53b259ea33f5/mssql-tools18_18.3.1.1-1_amd64.apk && \\
+    apk add --allow-untrusted msodbcsql18_18.3.2.1-1_amd64.apk && \\
+    apk add --allow-untrusted mssql-tools18_18.3.1.1-1_amd64.apk && \\
+    rm *.apk
+
+# Add labels to identify this as a prebuilt SQL auth image
+LABEL platform.sqlauth.prebuilt="true"
+LABEL platform.sqlauth.packages="krb5,msodbcsql18,mssql-tools18,freetds"
+
+# Verify installations
+RUN which klist && which kinit && echo "✓ Kerberos tools installed"
+RUN ls -la /opt/mssql-tools18/bin/sqlcmd || echo "sqlcmd in different location"
+RUN test -f /opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.so && echo "✓ ODBC driver installed" || echo "ODBC driver verification skipped"
+'''
+
+    # Write Dockerfile
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dockerfile_path = os.path.join(tmpdir, 'Dockerfile')
+        with open(dockerfile_path, 'w') as f:
+            f.write(dockerfile_content)
+
+        print("1. Building image with Kerberos and SQL packages...")
+
+        # Build the image
+        build_cmd = ['docker', 'build', '-t', mock_name, '-f', dockerfile_path, tmpdir]
+        returncode, stdout, stderr = run_command(build_cmd)
+
+        if returncode != 0:
+            print(f"{Colors.RED}Failed to build image{Colors.RESET}")
+            if stderr:
+                print(f"Error: {stderr}")
+            return False
+
+    print(f"\n{Colors.GREEN}✅ SQL Auth testing image created!{Colors.RESET}")
+    print(f"Image: {Colors.BOLD}{mock_name}{Colors.RESET}")
+
+    # Verify it exists
+    print(f"\n2. Verifying image...")
+    returncode, stdout, _ = run_command(
+        ['docker', 'images', mock_name, '--format', '{{.Repository}}:{{.Tag}} {{.Size}}'],
+        capture=True
+    )
+    if returncode == 0 and stdout:
+        print(f"   {stdout.strip()}")
+
+    # Test the tools in the image
+    print(f"\n3. Testing installed tools...")
+
+    # Test Kerberos tools
+    test_cmd = ['docker', 'run', '--rm', mock_name, 'sh', '-c', 'klist -V 2>&1']
+    returncode, stdout, stderr = run_command(test_cmd, capture=True)
+    if returncode == 0 or 'klist' in (stdout or '') + (stderr or ''):
+        print(f"{Colors.GREEN}   ✓ Kerberos tools working{Colors.RESET}")
+    else:
+        print(f"{Colors.YELLOW}   ⚠ Could not verify Kerberos tools{Colors.RESET}")
+
+    # Test SQL tools (might be in /opt/mssql-tools18/bin)
+    test_cmd = ['docker', 'run', '--rm', mock_name, 'sh', '-c',
+                'PATH=$PATH:/opt/mssql-tools18/bin && which sqlcmd 2>&1']
+    returncode, stdout, stderr = run_command(test_cmd, capture=True)
+    if 'sqlcmd' in (stdout or ''):
+        print(f"{Colors.GREEN}   ✓ SQL tools installed{Colors.RESET}")
+    else:
+        print(f"{Colors.YELLOW}   ⚠ SQL tools location varies by installation{Colors.RESET}")
+
+    print(f"\n{Colors.BOLD}Ready for SQL auth testing!{Colors.RESET}")
+    print(f"This image contains:")
+    print(f"  • Kerberos client libraries (krb5)")
+    print(f"  • Microsoft ODBC Driver 18 for SQL Server")
+    print(f"  • Microsoft SQL Server command line tools")
+    print(f"  • FreeTDS libraries")
+
+    return True
+
 def build_kerberos_image(mock_name, source_image=None):
     """Build a Kerberos image with all required packages and tag with corporate name.
 
@@ -167,10 +288,36 @@ def build_kerberos_image(mock_name, source_image=None):
     print(f"Base: {Colors.YELLOW}{source_image}{Colors.RESET}")
     print(f"Target: {Colors.YELLOW}{mock_name}{Colors.RESET}\n")
 
-    # Create temporary Dockerfile
-    dockerfile_content = f'''FROM {source_image}
+    # Detect if base image is Alpine or Debian/Ubuntu
+    # We'll check by trying to detect package manager in the base image
+    detect_cmd = ['docker', 'run', '--rm', source_image, 'sh', '-c', 'which apk 2>/dev/null || which apt-get 2>/dev/null']
+    returncode, stdout, _ = run_command(detect_cmd, capture=True)
 
-# Install Kerberos packages as documented in the platform
+    is_alpine = 'apk' in (stdout or '')
+
+    # Create temporary Dockerfile with appropriate package manager
+    if is_alpine:
+        # Alpine-based (includes Wolfi)
+        dockerfile_content = f'''FROM {source_image}
+
+# Install Kerberos packages for Alpine/Wolfi
+RUN apk add --no-cache \\
+    krb5 \\
+    krb5-libs \\
+    krb5-dev
+
+# Add label to identify this as a prebuilt image
+LABEL platform.kerberos.prebuilt="true"
+LABEL platform.kerberos.packages="krb5,krb5-libs,krb5-dev"
+
+# Verify installation
+RUN which klist && which kinit && echo "✓ Kerberos tools installed"
+'''
+    else:
+        # Debian/Ubuntu-based
+        dockerfile_content = f'''FROM {source_image}
+
+# Install Kerberos packages for Debian/Ubuntu
 RUN apt-get update && apt-get install -y --no-install-recommends \\
     krb5-user \\
     libkrb5-dev \\
@@ -239,6 +386,179 @@ RUN which klist && which kinit && echo "✓ Kerberos tools installed"
 
     return True
 
+def setup_test_images():
+    """Create all test images defined in test-images.yaml."""
+    test_file = Path('test-images.yaml')
+    if not test_file.exists():
+        print(f"{Colors.RED}test-images.yaml not found{Colors.RESET}")
+        return False
+
+    try:
+        with open(test_file, 'r') as f:
+            config = yaml.safe_load(f)
+    except Exception as e:
+        print(f"{Colors.RED}Failed to read test-images.yaml: {e}{Colors.RESET}")
+        return False
+
+    test_images = config.get('test_images', {})
+    if not test_images:
+        print(f"{Colors.YELLOW}No test images defined{Colors.RESET}")
+        return True
+
+    print(f"\n{Colors.BOLD}Setting Up Test Images{Colors.RESET}")
+    print(f"Creating {len(test_images)} test images...\n")
+
+    success_count = 0
+    for name, image_config in test_images.items():
+        print(f"\n{Colors.BLUE}[{name}]{Colors.RESET}")
+        print(f"  {image_config.get('description', 'No description')}")
+
+        image_type = image_config.get('type', 'tag')
+        mock_name = image_config.get('mock_name')
+        source_image = image_config.get('source_image')
+
+        if not mock_name:
+            print(f"  {Colors.RED}✗ Missing mock_name{Colors.RESET}")
+            continue
+
+        # Check if already exists
+        returncode, stdout, _ = run_command(
+            ['docker', 'images', mock_name, '--format', '{{.Repository}}:{{.Tag}}'],
+            capture=True
+        )
+        if returncode == 0 and stdout.strip():
+            print(f"  {Colors.YELLOW}⚠ Already exists, skipping{Colors.RESET}")
+            success_count += 1
+            continue
+
+        # Create based on type
+        if image_type == 'tag':
+            if create_mock_image(mock_name, source_image):
+                success_count += 1
+                print(f"  {Colors.GREEN}✓ Created{Colors.RESET}")
+            else:
+                print(f"  {Colors.RED}✗ Failed to create{Colors.RESET}")
+        elif image_type == 'build-kerberos':
+            if build_kerberos_image(mock_name, source_image):
+                success_count += 1
+                print(f"  {Colors.GREEN}✓ Built{Colors.RESET}")
+            else:
+                print(f"  {Colors.RED}✗ Failed to build{Colors.RESET}")
+        elif image_type == 'build-sql-auth':
+            if build_sql_auth_image(mock_name, source_image):
+                success_count += 1
+                print(f"  {Colors.GREEN}✓ Built SQL auth image{Colors.RESET}")
+            else:
+                print(f"  {Colors.RED}✗ Failed to build SQL auth{Colors.RESET}")
+        else:
+            print(f"  {Colors.RED}✗ Unknown type: {image_type}{Colors.RESET}")
+
+    print(f"\n{Colors.BOLD}Summary:{Colors.RESET}")
+    print(f"  Created: {success_count}/{len(test_images)} images")
+
+    if success_count == len(test_images):
+        print(f"\n{Colors.GREEN}✅ All test images ready!{Colors.RESET}")
+        return True
+    else:
+        print(f"\n{Colors.YELLOW}⚠ Some images failed{Colors.RESET}")
+        return False
+
+def teardown_test_images():
+    """Remove all test images defined in test-images.yaml."""
+    test_file = Path('test-images.yaml')
+    if not test_file.exists():
+        print(f"{Colors.RED}test-images.yaml not found{Colors.RESET}")
+        return False
+
+    try:
+        with open(test_file, 'r') as f:
+            config = yaml.safe_load(f)
+    except Exception as e:
+        print(f"{Colors.RED}Failed to read test-images.yaml: {e}{Colors.RESET}")
+        return False
+
+    test_images = config.get('test_images', {})
+    if not test_images:
+        print(f"{Colors.YELLOW}No test images defined{Colors.RESET}")
+        return True
+
+    print(f"\n{Colors.BOLD}Tearing Down Test Images{Colors.RESET}")
+    print(f"Removing {len(test_images)} test images...\n")
+
+    success_count = 0
+    for name, image_config in test_images.items():
+        mock_name = image_config.get('mock_name')
+        if not mock_name:
+            continue
+
+        print(f"{Colors.BLUE}[{name}]{Colors.RESET} {mock_name}")
+        if remove_mock_image(mock_name):
+            success_count += 1
+
+    print(f"\n{Colors.BOLD}Summary:{Colors.RESET}")
+    print(f"  Removed: {success_count}/{len(test_images)} images")
+    return success_count == len(test_images)
+
+def show_test_status():
+    """Show status of all test images defined in test-images.yaml."""
+    test_file = Path('test-images.yaml')
+    if not test_file.exists():
+        print(f"{Colors.RED}test-images.yaml not found{Colors.RESET}")
+        return False
+
+    try:
+        with open(test_file, 'r') as f:
+            config = yaml.safe_load(f)
+    except Exception as e:
+        print(f"{Colors.RED}Failed to read test-images.yaml: {e}{Colors.RESET}")
+        return False
+
+    test_images = config.get('test_images', {})
+    if not test_images:
+        print(f"{Colors.YELLOW}No test images defined{Colors.RESET}")
+        return True
+
+    print(f"\n{Colors.BOLD}Test Image Status{Colors.RESET}")
+    print("=" * 80)
+
+    exists_count = 0
+    for name, image_config in test_images.items():
+        mock_name = image_config.get('mock_name')
+        description = image_config.get('description', 'No description')
+
+        if not mock_name:
+            continue
+
+        # Check if exists
+        returncode, stdout, _ = run_command(
+            ['docker', 'images', mock_name, '--format', '{{.Repository}}:{{.Tag}}\t{{.Size}}'],
+            capture=True
+        )
+
+        print(f"\n{Colors.BLUE}[{name}]{Colors.RESET}")
+        print(f"  Description: {description}")
+        print(f"  Image: {mock_name}")
+
+        if returncode == 0 and stdout.strip():
+            exists_count += 1
+            parts = stdout.strip().split('\t')
+            size = parts[1] if len(parts) > 1 else 'unknown'
+            print(f"  Status: {Colors.GREEN}✓ EXISTS{Colors.RESET} (Size: {size})")
+        else:
+            print(f"  Status: {Colors.YELLOW}✗ NOT FOUND{Colors.RESET}")
+
+    print(f"\n{Colors.BOLD}Summary:{Colors.RESET}")
+    print(f"  {exists_count}/{len(test_images)} test images exist")
+
+    if exists_count == 0:
+        print(f"\n💡 Run: {Colors.GREEN}./mock-corporate-image.py test-setup{Colors.RESET} to create test images")
+    elif exists_count < len(test_images):
+        print(f"\n💡 Some images missing. Run: {Colors.GREEN}./mock-corporate-image.py test-setup{Colors.RESET} to create them")
+    else:
+        print(f"\n{Colors.GREEN}✅ All test images are ready!{Colors.RESET}")
+
+    return True
+
 def list_mock_images():
     """List potential mock corporate images (those with registry-like names)."""
     print(f"\n{Colors.BOLD}Potential Mock Corporate Images{Colors.RESET}")
@@ -287,26 +607,22 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Create a mock PostgreSQL using corporate registry naming:
+  # Test Commands - Use test-images.yaml configuration:
+  ./mock-corporate-image.py test-setup      # Create all test images
+  ./mock-corporate-image.py test-status     # Check status of test images
+  ./mock-corporate-image.py test-teardown   # Remove all test images
+
+  # Manual Commands - Create individual images:
   ./mock-corporate-image.py create mycorp.jfrog.io/docker-mirror/postgres/17.5:2025.10.01
-
-  # Build a prebuilt Kerberos image with all required packages:
-  ./mock-corporate-image.py build-kerberos mycorp.jfrog.io/platform/kerberos-sidecar:ubuntu-22.04
-
-  # Build Kerberos with custom base image:
-  ./mock-corporate-image.py build-kerberos mycorp.jfrog.io/kerberos:v1 --source debian:12-slim
-
-  # Remove a mock image:
+  ./mock-corporate-image.py build-kerberos mycorp.jfrog.io/platform/kerberos:v1
   ./mock-corporate-image.py remove mycorp.jfrog.io/docker-mirror/postgres/17.5:2025.10.01
-
-  # List all potential mock images:
   ./mock-corporate-image.py list
         """
     )
 
     parser.add_argument(
         'command',
-        choices=['create', 'remove', 'list', 'build-kerberos'],
+        choices=['create', 'remove', 'list', 'build-kerberos', 'build-sql-auth', 'test-setup', 'test-teardown', 'test-status'],
         help='Command to execute'
     )
 
@@ -354,6 +670,28 @@ Examples:
 
             success = build_kerberos_image(args.mock_name, args.source)
             sys.exit(0 if success else 1)
+
+        elif args.command == 'build-sql-auth':
+            if not args.mock_name:
+                print(f"{Colors.RED}Error: image_name is required for build-sql-auth command{Colors.RESET}")
+                print("\nExample:")
+                print("  ./mock-corporate-image.py build-sql-auth mycorp.jfrog.io/platform/sql-auth:latest")
+                sys.exit(1)
+
+            success = build_sql_auth_image(args.mock_name, args.source)
+            sys.exit(0 if success else 1)
+
+        elif args.command == 'test-setup':
+            success = setup_test_images()
+            sys.exit(0 if success else 1)
+
+        elif args.command == 'test-teardown':
+            success = teardown_test_images()
+            sys.exit(0 if success else 1)
+
+        elif args.command == 'test-status':
+            show_test_status()
+            sys.exit(0)
 
     except KeyboardInterrupt:
         print(f"\n{Colors.YELLOW}Interrupted by user{Colors.RESET}")

--- a/test-images.yaml
+++ b/test-images.yaml
@@ -1,0 +1,129 @@
+# Test Image Configuration
+# ========================
+# This file contains test cases for complex corporate Docker image paths
+# used to verify the platform installer works correctly with enterprise
+# registry naming conventions.
+#
+# Usage:
+#   ./mock-corporate-image.py test-setup     # Create all test images
+#   ./mock-corporate-image.py test-teardown  # Remove all test images
+#   ./mock-corporate-image.py test-status    # Show status of test images
+
+test_images:
+  # Complex PostgreSQL image from corporate registry with nested paths
+  postgres_corporate_complex:
+    description: "Complex corporate PostgreSQL image with deep registry path"
+    type: "tag"  # Simple tagging of existing image
+    source_image: "postgres:17.5-alpine"
+    mock_name: "mycorp.jfrog.io/docker-mirror/mycorp-approved-images/postgres/17.5:2025.10.01"
+    use_case: "Tests handling of deep registry paths with multiple segments and date-based tags"
+
+  # Alternative PostgreSQL with port number in registry
+  postgres_with_port:
+    description: "PostgreSQL from registry with port number"
+    type: "tag"
+    source_image: "postgres:17.5-alpine"
+    mock_name: "internal.artifactory.company.com:8443/docker-prod/postgres/17.5:v2025.10-hardened"
+    use_case: "Tests handling of registry URLs with port numbers"
+
+  # Kerberos prebuilt image with packages
+  kerberos_prebuilt_ubuntu:
+    description: "Prebuilt Kerberos image based on Ubuntu"
+    type: "build-kerberos"
+    source_image: "ubuntu:22.04"
+    mock_name: "mycorp.jfrog.io/platform/kerberos-sidecar:ubuntu-22.04-prebuilt"
+    use_case: "Tests prebuilt Kerberos images with all packages installed"
+
+  # Kerberos with complex path based on Debian
+  kerberos_prebuilt_debian:
+    description: "Prebuilt Kerberos on Debian from complex registry"
+    type: "build-kerberos"
+    source_image: "debian:12-slim"
+    mock_name: "company.registry.io:5000/security/kerberos/debian:12-slim-krb5-v1.20"
+    use_case: "Tests Kerberos with different base OS and complex naming"
+
+  # OpenMetadata server image
+  openmetadata_server:
+    description: "OpenMetadata server from corporate registry"
+    type: "tag"
+    source_image: "openmetadata/server:1.5.11"
+    mock_name: "artifactory.corp.net/docker-public/openmetadata/server:1.5.11-approved"
+    use_case: "Tests OpenMetadata server image handling"
+
+  # OpenSearch for OpenMetadata
+  opensearch_corporate:
+    description: "OpenSearch from corporate registry"
+    type: "tag"
+    source_image: "opensearchproject/opensearch:2.18.0"
+    mock_name: "docker-registry.internal.company.com/data/opensearch:2.18.0-enterprise"
+    use_case: "Tests OpenSearch image with corporate naming"
+
+  # Authentication-restricted scenario base image (Wolfi/Alpine)
+  wolfi_base:
+    description: "Corporate base image (Wolfi/Alpine) requiring auth to pull"
+    type: "tag"
+    source_image: "alpine:3.19"  # Using Alpine as Wolfi substitute
+    mock_name: "mycorp.jfrog.io/docker-mirror/mycorp-approved-images/wolfi-base:latest"
+    use_case: "Simulates auth-restricted base image that requires credentials"
+
+  # Prebuilt Kerberos from auth-restricted base
+  kerberos_base_prebuilt:
+    description: "Prebuilt Kerberos image from auth-restricted Wolfi base"
+    type: "build-kerberos"
+    source_image: "mycorp.jfrog.io/docker-mirror/mycorp-approved-images/wolfi-base:latest"
+    mock_name: "mycorp.jfrog.io/docker-mirror/mycorp-approved-images/kerberos-base:latest"
+    use_case: "Simulates prebuilt Kerberos when base requires auth"
+
+  # SQL Auth testing image with Kerberos + Microsoft SQL drivers
+  sql_auth_base_prebuilt:
+    description: "Prebuilt SQL auth testing image with Kerberos + MSSQL drivers"
+    type: "build-sql-auth"
+    source_image: "mycorp.jfrog.io/docker-mirror/mycorp-approved-images/wolfi-base:latest"
+    mock_name: "mycorp.jfrog.io/docker-mirror/mycorp-approved-images/sql-auth-base:latest"
+    use_case: "Tests SQL authentication with prebuilt Kerberos and Microsoft drivers"
+
+# Test scenarios to validate
+test_scenarios:
+  - name: "PostgreSQL Custom Image Persistence"
+    description: "Verify custom PostgreSQL image persists across wizard runs"
+    steps:
+      - "Create mock: postgres_corporate_complex"
+      - "Run ./platform setup with custom image"
+      - "Verify image is stored in platform-bootstrap/.env"
+      - "Run ./platform setup again"
+      - "Verify wizard remembers the custom image"
+      - "Run ./platform clean-slate"
+      - "Verify custom image is properly removed"
+
+  - name: "Kerberos Prebuilt Image"
+    description: "Verify prebuilt Kerberos images work correctly"
+    steps:
+      - "Create mock: kerberos_prebuilt_ubuntu"
+      - "Run ./platform setup and select Kerberos"
+      - "Use the prebuilt image and select 'prebuilt' mode"
+      - "Verify Kerberos container starts with packages installed"
+      - "Run ./platform clean-slate"
+      - "Verify image is removed"
+
+  - name: "Multiple Service Custom Images"
+    description: "Test multiple services with custom images"
+    steps:
+      - "Create all mocks"
+      - "Setup PostgreSQL with postgres_corporate_complex"
+      - "Setup OpenMetadata with custom server and opensearch images"
+      - "Setup Kerberos with prebuilt image"
+      - "Verify all services retain custom images on re-run"
+      - "Clean slate and verify all removed"
+
+  - name: "Authentication-Restricted Prebuilt Images"
+    description: "Simulate environment where base images require auth to pull"
+    steps:
+      - "Create wolfi_base mock (simulates auth-required base)"
+      - "Build kerberos_base_prebuilt from wolfi_base"
+      - "Build sql_auth_base_prebuilt from wolfi_base"
+      - "Run ./platform setup with prebuilt mode"
+      - "Use kerberos_base_prebuilt for Kerberos sidecar"
+      - "Use sql_auth_base_prebuilt for SQL auth testing"
+      - "Verify containers start without trying to pull base images"
+      - "Verify Kerberos ticket sharing works"
+      - "Verify SQL authentication capabilities"


### PR DESCRIPTION
Enhanced mock utility and test configuration to support authentication-restricted enterprise scenarios where base images require credentials to pull.

Key additions:
- Added build_sql_auth_image() function for SQL auth testing images with Kerberos + MSSQL drivers
- Enhanced build_kerberos_image() to auto-detect Alpine vs Debian/Ubuntu bases
- Added 3 new auth-restricted test images:
  * wolfi_base: Simulates corporate base requiring auth (using Alpine as Wolfi proxy)
  * kerberos_base_prebuilt: Prebuilt Kerberos from auth-restricted base
  * sql_auth_base_prebuilt: Prebuilt SQL auth with Kerberos + MSSQL drivers
- All Alpine/Wolfi images correctly use apk package management
- Added test scenarios for environments that cannot layer images at runtime

This enables testing of scenarios where:
- Corporate registries require authentication
- Images must be prebuilt with all dependencies
- Base images cannot be pulled without credentials
- Platform must use prebuilt mode exclusively