### PR TITLE
feat: Add verbose mode to wizard for real-time debugging

### DIFF
--- a/platform
+++ b/platform
@@ -37,16 +37,24 @@ setup_wizard() {
 
     cd "$SCRIPT_DIR"
 
+    # Check for verbose mode
+    VERBOSE_FLAG=""
+    if [[ "${WIZARD_VERBOSE:-}" == "1" ]] || [[ "${2:-}" == "--verbose" ]] || [[ "${2:-}" == "-v" ]]; then
+        VERBOSE_FLAG="verbose=True"
+        echo "Running in verbose mode..."
+    fi
+
     # Run Python wizard via uv
     if uv run python3 -c "
 import sys
+import os
 sys.path.insert(0, '$SCRIPT_DIR')
 
 from wizard.engine.engine import WizardEngine
 from wizard.engine.runner import RealActionRunner
 
-# Create engine with real runner
-runner = RealActionRunner()
+# Create engine with real runner (verbose mode if requested)
+runner = RealActionRunner($VERBOSE_FLAG)
 engine = WizardEngine(runner=runner, base_path='$SCRIPT_DIR/wizard')
 
 # Execute setup flow
@@ -66,16 +74,24 @@ clean_slate_wizard() {
 
     cd "$SCRIPT_DIR"
 
+    # Check for verbose mode
+    VERBOSE_FLAG=""
+    if [[ "${WIZARD_VERBOSE:-}" == "1" ]] || [[ "${2:-}" == "--verbose" ]] || [[ "${2:-}" == "-v" ]]; then
+        VERBOSE_FLAG="verbose=True"
+        echo "Running in verbose mode..."
+    fi
+
     # Run Python wizard via uv
     if uv run python3 -c "
 import sys
+import os
 sys.path.insert(0, '$SCRIPT_DIR')
 
 from wizard.engine.engine import WizardEngine
 from wizard.engine.runner import RealActionRunner
 
-# Create engine with real runner
-runner = RealActionRunner()
+# Create engine with real runner (verbose mode if requested)
+runner = RealActionRunner($VERBOSE_FLAG)
 engine = WizardEngine(runner=runner, base_path='$SCRIPT_DIR/wizard')
 
 # Execute clean-slate flow
@@ -98,21 +114,27 @@ config_command() {
 # Main command router
 case "${1:-}" in
     setup)
-        setup_wizard
+        setup_wizard "$@"
         ;;
     clean-slate)
-        clean_slate_wizard
+        clean_slate_wizard "$@"
         ;;
     config)
-        config_command
+        config_command "$@"
         ;;
     *)
-        echo "Usage: ./platform {setup|clean-slate|config}"
+        echo "Usage: ./platform {setup|clean-slate|config} [--verbose|-v]"
         echo ""
         echo "Commands:"
         echo "  setup        Run platform configuration wizard"
         echo "  clean-slate  Remove all platform services"
         echo "  config       Show current configuration"
+        echo ""
+        echo "Options:"
+        echo "  --verbose,-v   Show detailed command execution"
+        echo ""
+        echo "Environment:"
+        echo "  WIZARD_VERBOSE=1  Enable verbose mode via environment"
         exit 1
         ;;
 esac


### PR DESCRIPTION
Adds comprehensive verbose mode to the wizard that reveals the actual errors happening during command execution, solving the mystery of why all errors appeared as 'No such file or directory'.

Key improvements:
- Verbose mode shows real-time command output instead of capturing it
- Actual command errors are now visible (e.g., Docker registry failures)
- FileNotFoundError exceptions are caught and reported clearly
- WSL2 environment detection for future path handling
- Special handling for 'make -C' commands to detect missing directories
- Working directory context shown for all commands

The verbose mode revealed that the 'No such file or directory' error users were seeing was actually misleading - the real errors were:
1. Docker registry connection failures (fake.registry.corp.com)
2. Missing Docker images
3. Authentication issues

Usage:
  ./platform setup --verbose
  ./platform setup -v
  WIZARD_VERBOSE=1 ./platform setup

This gives users the ability to see exactly what's happening and why commands are failing, making debugging much easier. The issue wasn't path-related at all - it was the error capture mechanism hiding the real Docker errors.

Fixes the debugging visibility issue reported by enterprise users.