### PR TITLE
fix: Add missing use_prebuilt prompt for Kerberos service

### DIFF
--- a/wizard/services/kerberos/spec.yaml
+++ b/wizard/services/kerberos/spec.yaml
@@ -23,6 +23,16 @@ steps:
     prompt: "Enter Docker image for Kerberos (e.g., ubuntu:22.04):"
     default_value: "ubuntu:22.04"
     validator: kerberos.validate_image_url
+    next:
+      when_changed: use_prebuilt_input
+      when_unchanged: test_kerberos_action
+
+  - id: use_prebuilt_input
+    type: boolean
+    state_key: services.kerberos.use_prebuilt
+    default_from: services.kerberos.use_prebuilt
+    prompt: "Is this a prebuilt image with Kerberos packages already installed?"
+    default_value: false
     next: test_kerberos_action
 
   - id: test_kerberos_action


### PR DESCRIPTION
Kerberos was missing the prompt to ask if an image is prebuilt, causing it to always default to false and attempt package installation even on prebuilt corporate images.

The bug:
- Kerberos spec.yaml had no use_prebuilt prompt
- Actions defaulted to False: ctx.get('services.kerberos.use_prebuilt', False)
- This meant prebuilt corporate images would have packages installed again
- Only worked if manually edited in platform-config.yaml

The fix:
- Added use_prebuilt prompt that appears when image is changed
- Preserves existing values when image unchanged
- Correctly identifies prebuilt corporate images

This is important because:
1. Corporate images like 'kerberos-base:latest' already have krb5 packages
2. Installing packages again wastes time and may fail in restricted environments
3. Prebuilt images are the recommended approach for corporate deployments

Now the flow is:
1. Ask for Kerberos domain
2. Ask for image
3. If image changed, ask if it's prebuilt
4. Skip package installation if prebuilt=true