### PR TITLE
fix: Remove confusing prebuilt prompt for PostgreSQL

### DIFF
--- a/wizard/services/postgres/spec.yaml
+++ b/wizard/services/postgres/spec.yaml
@@ -13,15 +13,6 @@ steps:
     default_from: services.postgres.image
     default_value: postgres:17.5-alpine
     validator: postgres.validate_image_url
-    next:
-      when_changed: postgres_prebuilt
-      when_unchanged: postgres_auth
-
-  - id: postgres_prebuilt
-    type: boolean
-    prompt: "Use prebuilt image?"
-    state_key: services.postgres.prebuilt
-    default_value: false
     next: postgres_auth
 
   - id: postgres_auth


### PR DESCRIPTION
PostgreSQL doesn't build or layer anything onto images - it uses them directly as-is. The 'prebuilt' question was confusing users since:

1. PostgreSQL just uses 'docker-compose.yml' with 'image:' directive
2. No Dockerfile exists for PostgreSQL (unlike Kerberos)
3. No packages are installed or customizations layered
4. Configuration is done via environment variables and mounted scripts

Changes:
- Removed 'prebuilt' prompt from PostgreSQL wizard flow
- Simplified pull_image action to remove prebuilt logic
- Updated documentation to clarify PostgreSQL uses images directly
- Removed prebuilt flag from saved configuration

This improves UX by only asking about prebuilt images for services that actually build/customize images (like Kerberos which installs krb5 packages via Dockerfile).

PostgreSQL now has a simpler, clearer flow:
1. Ask for image
2. Ask for auth method
3. Pull and use the image as-is