### PR TITLE
docs: Improve corporate registry example in platform config template

### DIFF
--- a/platform-config.yaml.example
+++ b/platform-config.yaml.example
@@ -7,6 +7,6 @@ services:
   postgres:
     auth_method: trust
     enabled: true
-    image: fake.registry.corp.com/postgres/special:99.99
+    image: mycorp.jfrog.io/docker-mirror/mycorp-approved-images/postgres/17.5:2025.10.01
     password: null
     prebuilt: false


### PR DESCRIPTION
## Summary
- Updates the PostgreSQL image example in `platform-config.yaml.example` to show a more realistic corporate registry structure
- Replaces generic `fake.registry.corp.com` with a JFrog Artifactory example that better represents enterprise environments
- Demonstrates proper versioning and path structures commonly used in corporate settings

## Changes
- Changed from: `fake.registry.corp.com/postgres/special:99.99`
- Changed to: `mycorp.jfrog.io/docker-mirror/mycorp-approved-images/postgres/17.5:2025.10.01`

## Why this matters
This provides a better example for users in corporate environments who need to configure the platform with their internal registries. The new format demonstrates:
- **JFrog Artifactory** - Widely used enterprise artifact repository
- **Nested paths** - Shows `docker-mirror/mycorp-approved-images` structure typical in enterprises
- **Proper versioning** - Includes both upstream version (17.5) and corporate date stamp (2025.10.01)
- **Corporate approval process** - Path structure reflects images that have gone through corporate vetting

This small change helps enterprise users immediately understand how to configure their registry paths correctly.

## Test plan
- [x] Verified the example file syntax is valid YAML
- [x] Confirmed this aligns with recent corporate environment improvements (#115)
- [x] Example path follows standard JFrog Artifactory conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)