### PR TITLE
Phase 1: Add migration for services.postgres → services.base_platform refactor

### DIFF
--- a/wizard/services/postgres/tests/test_migration.py
+++ b/wizard/services/postgres/tests/test_migration.py
@@ -1,0 +1,89 @@
+"""Test migration from services.postgres to services.base_platform."""
+
+import pytest
+from unittest.mock import Mock
+from wizard.services.postgres.actions import migrate_legacy_postgres_config
+
+
+class TestLegacyPostgresMigration:
+    """Test migration of old services.postgres keys to services.base_platform."""
+
+    def test_migrates_postgres_keys_to_base_platform(self):
+        """Should migrate all services.postgres.* keys to services.base_platform.postgres.*"""
+        # Arrange - Create context with old keys
+        ctx = {
+            'services.postgres.enabled': True,
+            'services.postgres.image': 'postgres:17.5-alpine',
+            'services.postgres.port': 5432,
+            'services.postgres.user': 'platform_admin',
+            'services.postgres.password': 'changeme',
+            'services.postgres.passwordless': False
+        }
+
+        mock_runner = Mock()
+        mock_runner.save_config = Mock()
+
+        # Act - Run migration
+        migrate_legacy_postgres_config(ctx, mock_runner)
+
+        # Assert - New keys should exist
+        assert ctx.get('services.base_platform.postgres.enabled') == True
+        assert ctx.get('services.base_platform.postgres.image') == 'postgres:17.5-alpine'
+        assert ctx.get('services.base_platform.postgres.port') == 5432
+        assert ctx.get('services.base_platform.postgres.user') == 'platform_admin'
+        assert ctx.get('services.base_platform.postgres.password') == 'changeme'
+        assert ctx.get('services.base_platform.postgres.passwordless') == False
+
+        # Assert - Old keys should be deleted
+        assert 'services.postgres.enabled' not in ctx
+        assert 'services.postgres.image' not in ctx
+        assert 'services.postgres.port' not in ctx
+        assert 'services.postgres.user' not in ctx
+        assert 'services.postgres.password' not in ctx
+        assert 'services.postgres.passwordless' not in ctx
+
+    def test_does_nothing_when_no_old_keys_present(self):
+        """Should be idempotent - safe to run when no old keys exist."""
+        # Arrange - Context already has new keys
+        ctx = {
+            'services.base_platform.postgres.enabled': True,
+            'services.base_platform.postgres.image': 'postgres:17.5-alpine'
+        }
+
+        mock_runner = Mock()
+        mock_runner.save_config = Mock()
+
+        # Act - Run migration
+        migrate_legacy_postgres_config(ctx, mock_runner)
+
+        # Assert - New keys still exist unchanged
+        assert ctx.get('services.base_platform.postgres.enabled') == True
+        assert ctx.get('services.base_platform.postgres.image') == 'postgres:17.5-alpine'
+
+        # Assert - No errors occurred
+        assert mock_runner.save_config.call_count <= 1
+
+    def test_saves_config_after_migration(self):
+        """Should save updated config after migration."""
+        # Arrange
+        ctx = {
+            'services.postgres.enabled': True,
+            'services.postgres.image': 'postgres:17.5-alpine'
+        }
+
+        mock_runner = Mock()
+        mock_runner.save_config = Mock()
+
+        # Act
+        migrate_legacy_postgres_config(ctx, mock_runner)
+
+        # Assert - save_config was called
+        mock_runner.save_config.assert_called_once()
+
+        # Verify the saved config has the new structure
+        call_args = mock_runner.save_config.call_args[0]
+        saved_config = call_args[0]
+
+        assert 'services' in saved_config
+        assert 'base_platform' in saved_config['services']
+        assert 'postgres' in saved_config['services']['base_platform']


### PR DESCRIPTION
## Summary
First step of Phase 1 refactor: Implements migration logic for renaming `services.postgres` → `services.base_platform.postgres`.

## Background
PostgreSQL is not a standalone service - it's base platform infrastructure. This refactor corrects the architectural misnomer. See design doc: `docs/plans/2025-11-01-base-platform-refactor-and-test-containers.md`

## What's in this PR
- ✅ Migration action: `migrate_legacy_postgres_config()`
- ✅ Comprehensive tests (3 test cases, all passing)
- ✅ Idempotent migration logic
- ✅ Automatic detection and migration of old keys
- ✅ Old keys deleted after migration

## Migration Logic
```python
services.postgres.enabled     → services.base_platform.postgres.enabled
services.postgres.image       → services.base_platform.postgres.image
services.postgres.port        → services.base_platform.postgres.port
services.postgres.user        → services.base_platform.postgres.user
services.postgres.password    → services.base_platform.postgres.password
services.postgres.passwordless → services.base_platform.postgres.passwordless
```

## What's NOT in this PR (coming next)
This PR only adds the migration function. The full refactor includes:
- [ ] Rename directory postgres/ → base_platform/
- [ ] Update all state key references in code
- [ ] Update specs and flows
- [ ] Update imports
- [ ] Update all tests
- [ ] Integrate migration as first step in spec

## Testing
```bash
pytest wizard/services/postgres/tests/test_migration.py -v
# 3 passed
```

## Next Steps
After merge, continue with directory rename and full codebase update.

## Related
- Design: `docs/plans/2025-11-01-base-platform-refactor-and-test-containers.md`
- Phase 2 (later): Add test container configuration

Co-Authored-By: Claude <noreply@anthropic.com>