### PR TITLE
fix: Remove test container images during clean-slate

### DIFF
--- a/wizard/services/base_platform/teardown_actions.py
+++ b/wizard/services/base_platform/teardown_actions.py
@@ -44,6 +44,7 @@ def remove_images(ctx: Dict[str, Any], runner: ActionRunner) -> None:
 
     Removes the PostgreSQL Docker image from local registry.
     Reads custom image from platform-bootstrap/.env if present.
+    Also removes test container images (postgres-test, sqlcmd-test).
 
     Args:
         ctx: Context dictionary with image configuration
@@ -66,11 +67,21 @@ def remove_images(ctx: Dict[str, Any], runner: ActionRunner) -> None:
     if not image:
         image = ctx.get('services.base_platform.postgres.image', 'postgres:17.5-alpine')
 
-    # Build command to remove image
+    # Build command to remove main postgres image
     command = ['docker', 'rmi', image, '--force']
-
-    # Execute command
     runner.run_shell(command)
+
+    # Remove test container images
+    test_images = [
+        'platform/postgres-test:latest',
+        'platform/sqlcmd-test:latest',
+        'test-postgres-build:latest',
+        'test-sqlcmd-build:latest'
+    ]
+
+    for test_image in test_images:
+        command = ['docker', 'rmi', test_image, '--force']
+        runner.run_shell(command)
 
 
 def clean_config(ctx: Dict[str, Any], runner: ActionRunner) -> None:


### PR DESCRIPTION
## Summary

Fixes issue where `make clean-slate` (via `./platform clean-slate`) was leaving Docker images behind after teardown.

## Problem

The `base_platform` service's `remove_images` action only removed the main PostgreSQL image (e.g., `postgres:17.5-alpine`) but didn't remove the test container images that were introduced in PR #131 (feature/test-container-config).

### Images Left Behind

After running clean-slate, these images remained:
- `platform/postgres-test:latest` - Built by `make build-postgres-test`
- `platform/sqlcmd-test:latest` - Built by `make build-sqlcmd-test`
- `test-postgres-build:latest` - Intermediate build image
- `test-sqlcmd-build:latest` - Intermediate build image

## Solution

Updated `wizard/services/base_platform/teardown_actions.py` to remove all test container images in addition to the main PostgreSQL image.

## Changes

- **teardown_actions.py**: Added removal of 4 test container images
- **test_postgres_teardown.py**: Added comprehensive test validating all images are removed
- **test_postgres_teardown.py**: Updated existing tests to accommodate multiple `docker rmi` calls

## Test Results

All 122 base_platform tests pass:
```
============================= test session starts ==============================
wizard/services/base_platform/tests/ - 122 passed in 0.30s
```

Key test:
- `test_remove_images_removes_test_container_images` - Verifies all 5 images are removed (main + 4 test images)

## Testing Approach

Followed TDD methodology:
1. **RED**: Wrote failing test expecting test container images to be removed
2. **GREEN**: Implemented minimal code to make test pass
3. **REFACTOR**: Updated existing tests to handle new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)