### PR TITLE
fix: Persist wizard selections across sessions (nested config & require_password)

### DIFF
--- a/wizard/services/base_platform/actions.py
+++ b/wizard/services/base_platform/actions.py
@@ -78,6 +78,7 @@ def save_config(ctx: Dict[str, Any], runner) -> None:
                 'postgres': {
                     'enabled': True,
                     'image': ctx.get('services.base_platform.postgres.image', 'postgres:17.5-alpine'),
+                    'require_password': require_password,
                     'auth_method': auth_method,
                     'password': password
                 }

--- a/wizard/services/base_platform/spec.yaml
+++ b/wizard/services/base_platform/spec.yaml
@@ -32,6 +32,7 @@ steps:
     type: boolean
     prompt: "Require password for PostgreSQL database?"
     state_key: services.base_platform.postgres.require_password
+    default_from: services.base_platform.postgres.require_password
     default_value: true
     next:
       when_value:
@@ -72,6 +73,7 @@ steps:
     type: boolean
     state_key: services.base_platform.test_containers.postgres_test.use_prebuilt
     prompt: "Will you use a prebuilt postgres-test image with packages already installed?"
+    default_from: services.base_platform.test_containers.postgres_test.use_prebuilt
     default_value: false
     next: postgres_test_image
 
@@ -79,6 +81,7 @@ steps:
     type: string
     state_key: services.base_platform.test_containers.postgres_test.image
     prompt: "Enter Docker image for postgres-test (e.g., alpine:latest or mycompany/postgres-test:latest for prebuilt):"
+    default_from: services.base_platform.test_containers.postgres_test.image
     default_value: "alpine:latest"
     validator: base_platform.validate_image_url
     next: sqlcmd_test_prebuilt
@@ -87,6 +90,7 @@ steps:
     type: boolean
     state_key: services.base_platform.test_containers.sqlcmd_test.use_prebuilt
     prompt: "Will you use a prebuilt sqlcmd-test image with packages already installed?"
+    default_from: services.base_platform.test_containers.sqlcmd_test.use_prebuilt
     default_value: false
     next: sqlcmd_test_image
 
@@ -94,6 +98,7 @@ steps:
     type: string
     state_key: services.base_platform.test_containers.sqlcmd_test.image
     prompt: "Enter Docker image for sqlcmd-test (e.g., alpine:latest or mycompany/sqlcmd-test:latest for prebuilt):"
+    default_from: services.base_platform.test_containers.sqlcmd_test.image
     default_value: "alpine:latest"
     validator: base_platform.validate_image_url
     next: save_test_config


### PR DESCRIPTION
## Summary

Fixes two critical issues where user selections weren't being remembered across wizard sessions, forcing users to re-enter the same choices every time.

## Issue 1: Nested Config Not Loaded (Test Container Images)

**Problem:** Test container image selections (postgres-test, sqlcmd-test) were not persisted across wizard runs. The config was saved correctly but not loaded properly on subsequent runs.

**Root Cause:** `_load_existing_state()` only flattened config 2 levels deep:
```
services.base_platform.test_containers = {entire dict}
```

But the spec expected 4-level keys:
```
services.base_platform.test_containers.postgres_test.image
services.base_platform.test_containers.postgres_test.use_prebuilt
```

**Fix:**
- Added recursive `_flatten_dict()` helper to engine.py
- Updated `_load_existing_state()` to recursively flatten all nested config
- Added `default_from` to test container fields in spec.yaml
- Added comprehensive test: `test_load_existing_state_handles_nested_config`

## Issue 2: require_password Not Persisted

**Problem:** User's choice for "Require password?" wasn't remembered. Every wizard run asked again even after user answered "n".

**Root Cause:** `save_config()` read `require_password` and derived `auth_method`, but only saved `auth_method` to YAML - not `require_password` itself.

**Fix:**
- Updated `save_config()` to save `require_password` field to YAML
- Added `default_from` to `postgres_auth` step in spec.yaml
- Added test: `test_save_config_persists_require_password_field`

## Test Results

✅ **All 586 tests passing**
- New test for nested config loading
- New test for require_password persistence
- All existing tests still pass
- Fixed `test_engine_execute_action_step` to filter config loading calls

## Trust Relationship

As noted in the issue: "There needs to be a trust relationship that what the wizard is told is adhered to by the installers."

This fix ensures:
1. ✅ User selections are persisted to platform-config.yaml
2. ✅ Saved config is correctly loaded on next run
3. ✅ Spec uses default_from to populate from saved state
4. ✅ Wizard respects previous answers as defaults

## Testing

To verify the fix:
1. Run `make setup` and choose custom values for:
   - "Require password?" → Answer **n**
   - Test container images → Choose non-default values
2. Run `make setup` again
3. ✅ Your previous answers should appear as defaults

## Files Changed

- `wizard/engine/engine.py` - Added recursive config flattening
- `wizard/services/base_platform/actions.py` - Save require_password field
- `wizard/services/base_platform/spec.yaml` - Added default_from for persistence
- `tests/test_engine.py` - Added nested config test
- `wizard/services/base_platform/tests/test_actions.py` - Added require_password test

🤖 Generated with [Claude Code](https://claude.com/claude-code)