### PR TITLE
fix: restore Microsoft ODBC drivers to sqlcmd-test container

### DIFF
--- a/docs/custom-image-requirements.md
+++ b/docs/custom-image-requirements.md
@@ -75,11 +75,12 @@ These containers are used by the platform to verify database connectivity and ar
 - **[SQL Server Test Container](../platform-infrastructure/test-containers/sqlcmd-test/Dockerfile)** - Tests SQL Server connectivity
   - Base: `alpine:latest`
   - Purpose: Validates SQL Server connectivity with Kerberos authentication
-  - Components: FreeTDS SQL Server client, Kerberos libraries, unixODBC
+  - Components: Microsoft ODBC Driver 18 (msodbcsql18), Microsoft SQL Server tools (mssql-tools18), Kerberos libraries, unixODBC
   - Security: Runs as non-root user (testuser, uid 10001)
-  - Note: Uses FreeTDS (open source) instead of Microsoft proprietary tools - no EULA required
+  - Note: Downloads Microsoft ODBC driver APKs from Microsoft's server during build
   - Build: `docker build -t platform/sqlcmd-test platform-infrastructure/test-containers/sqlcmd-test/`
   - Custom base: `--build-arg BASE_IMAGE=your.registry.com/alpine:3.19`
+  - Corporate Artifactory: `--build-arg ODBC_DRIVER_URL=https://artifactory.corp.com/mssql-drivers`
   - Required for: SQL Server connectivity validation (future feature)
 
 ### Platform Service Images

--- a/platform-infrastructure/test-containers/sqlcmd-test/Dockerfile
+++ b/platform-infrastructure/test-containers/sqlcmd-test/Dockerfile
@@ -1,71 +1,85 @@
 # =============================================================================
-# SQL Server Test Container Dockerfile (FreeTDS-based)
+# SQL Server Test Container Dockerfile (Microsoft ODBC Driver)
 # =============================================================================
 #
 # PURPOSE:
-#   Provides a minimal Alpine-based container with FreeTDS SQL Server client
-#   tools and Kerberos support for testing SQL Server connectivity with
-#   Kerberos authentication.
+#   Provides a minimal Alpine-based container with Microsoft SQL Server ODBC
+#   driver and tools for testing SQL Server connectivity with Kerberos
+#   authentication.
 #
 # FEATURES:
-#   - FreeTDS SQL Server client tools (open source alternative to mssql-tools)
+#   - Microsoft ODBC Driver 18 for SQL Server (msodbcsql18)
+#   - Microsoft SQL Server command-line tools (mssql-tools18)
 #   - Kerberos client libraries for authentication
 #   - unixODBC for ODBC-based database connectivity
 #   - Runs as non-root user (testuser, uid 10001)
 #   - Customizable base image via BASE_IMAGE build argument
-#   - No Microsoft proprietary tools or EULA requirements
+#   - Corporate Artifactory support via ODBC_DRIVER_URL build argument
 #
 # BUILD ARGUMENTS:
 #   BASE_IMAGE: Base image to use (default: alpine:latest)
 #               Can be overridden for corporate environments:
 #               --build-arg BASE_IMAGE=registry.corp.com/alpine:3.19-hardened
 #
+#   ODBC_DRIVER_URL: URL base for downloading Microsoft ODBC driver packages
+#                    Default: Microsoft download server
+#                    Corporate: Set to Artifactory mirror URL
+#
 # SECURITY:
 #   - Non-root user execution (principle of least privilege)
 #   - Minimal package installation (reduced attack surface)
 #   - No hardcoded credentials or secrets
-#   - No external downloads (all packages from Alpine repos)
 #
 # USAGE:
-#   Build with defaults:
-#     docker build -t sqlcmd-test .
+#   Build with defaults (downloads from Microsoft):
+#     docker build -t platform/sqlcmd-test .
 #
 #   Build with custom base image:
-#     docker build --build-arg BASE_IMAGE=alpine:3.19 -t sqlcmd-test .
+#     docker build --build-arg BASE_IMAGE=alpine:3.19 -t platform/sqlcmd-test .
+#
+#   Build with corporate Artifactory mirror:
+#     docker build \
+#       --build-arg BASE_IMAGE=artifactory.corp.com/alpine:3.19 \
+#       --build-arg ODBC_DRIVER_URL=https://artifactory.corp.com/mssql-drivers \
+#       -t platform/sqlcmd-test .
 #
 # MIGRATION NOTE:
 #   This replaces kerberos/kerberos-sidecar/Dockerfile.sqlcmd-test
 #   Changes from original:
-#   - Switched from Microsoft mssql-tools18 to FreeTDS (open source)
-#   - Removed MSSQL_TOOLS_URL download logic and complexity
-#   - Removed architecture detection logic
-#   - Removed .netrc authentication requirement
 #   - Added non-root user (testuser, uid 10001)
 #   - Standardized BASE_IMAGE build argument (was IMAGE_ALPINE)
-#   - All dependencies from Alpine repos (no external downloads)
+#   - Added ODBC_DRIVER_URL build argument for corporate flexibility
+#   - Simplified and documented the build process
 #
-# FREETDS vs MSSQL-TOOLS:
-#   FreeTDS provides functionally equivalent SQL Server connectivity:
-#   - Full T-SQL support via tsql and ODBC
-#   - Kerberos authentication support
-#   - Microsoft-compatible TDS protocol
-#   - No EULA restrictions
-#   - Better for air-gapped environments (no external downloads)
+# MICROSOFT DRIVERS:
+#   - msodbcsql18: Microsoft ODBC Driver 18 for SQL Server
+#   - mssql-tools18: sqlcmd and bcp command-line tools
+#   - Both are distributed as Alpine APK files by Microsoft
+#   - Kerberos authentication is fully supported
 #
 # =============================================================================
 
 ARG BASE_IMAGE=alpine:latest
 FROM ${BASE_IMAGE}
 
-# Install FreeTDS, Kerberos, and ODBC packages
-# Note: FreeTDS provides SQL Server connectivity without Microsoft proprietary tools
+# Install base packages: Kerberos, curl, unixODBC
+# Note: These must be installed BEFORE Microsoft ODBC drivers
 RUN apk add --no-cache \
     krb5 \
+    krb5-libs \
     curl \
+    gnupg \
     unixodbc \
-    unixodbc-dev \
-    freetds \
-    freetds-dev
+    unixodbc-dev
+
+# Install Microsoft ODBC Driver 18 for SQL Server
+# Corporate environments: Override ODBC_DRIVER_URL to use Artifactory mirror
+ARG ODBC_DRIVER_URL=https://download.microsoft.com/download/3/5/5/355d7943-a338-41a7-858d-53b259ea33f5
+RUN curl -O ${ODBC_DRIVER_URL}/msodbcsql18_18.3.2.1-1_amd64.apk && \
+    curl -O ${ODBC_DRIVER_URL}/mssql-tools18_18.3.1.1-1_amd64.apk && \
+    apk add --allow-untrusted msodbcsql18_18.3.2.1-1_amd64.apk && \
+    apk add --allow-untrusted mssql-tools18_18.3.1.1-1_amd64.apk && \
+    rm *.apk
 
 # Create non-root user for security
 RUN addgroup -g 10001 testuser && \


### PR DESCRIPTION
## Summary

Restores Microsoft ODBC Driver 18 and mssql-tools18 to the sqlcmd-test container, replacing the FreeTDS implementation that was incorrectly substituted.

## Issue

The `platform-infrastructure/test-containers/sqlcmd-test/Dockerfile` had been changed to use FreeTDS (open-source alternative), but the original requirements specified Microsoft's proprietary ODBC drivers for SQL Server connectivity testing.

## Changes

### Dockerfile Changes
- Restored Microsoft ODBC Driver 18 (msodbcsql18) installation
- Restored Microsoft SQL Server tools (mssql-tools18) installation
- Downloads APK files from Microsoft's server: `msodbcsql18_18.3.2.1-1_amd64.apk` and `mssql-tools18_18.3.1.1-1_amd64.apk`
- Added `ODBC_DRIVER_URL` build argument for corporate Artifactory support
- Removed FreeTDS packages (`freetds`, `freetds-dev`)

### Documentation Changes
- Updated `docs/custom-image-requirements.md` to accurately reflect Microsoft driver usage
- Added corporate Artifactory build argument example
- Corrected component list: "Microsoft ODBC Driver 18 (msodbcsql18), Microsoft SQL Server tools (mssql-tools18)"

## Corporate Environment Support

Corporate environments can override the download URL to use Artifactory mirrors:

```bash
docker build \
  --build-arg BASE_IMAGE=artifactory.corp.com/alpine:3.19 \
  --build-arg ODBC_DRIVER_URL=https://artifactory.corp.com/mssql-drivers \
  -t platform/sqlcmd-test .
```

## Verification

Tested with full teardown/setup cycle:

```bash
# Container builds successfully
✓ Test containers built successfully

# Microsoft drivers installed
docker exec sqlcmd-test ls /opt/microsoft/msodbcsql18
# Output: /opt/microsoft/msodbcsql18

# SQL Server tools installed
docker exec sqlcmd-test /opt/mssql-tools18/bin/sqlcmd -?
# Output: Microsoft (R) SQL Server Command Line Tool Version 18.3.0001.1

# ODBC driver registered
docker exec sqlcmd-test odbcinst -q -d
# Output: [ODBC Driver 18 for SQL Server]
```

## Files Changed

- `platform-infrastructure/test-containers/sqlcmd-test/Dockerfile` - Restored Microsoft drivers
- `docs/custom-image-requirements.md` - Updated documentation

## Image Size

- Container size: 40.9MB (vs 18MB for FreeTDS version)
- Microsoft drivers layer: 9.69MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>